### PR TITLE
feat: Mode-C plugin migration with Go shim + bundled JRE (#438 phase 8)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,9 +179,90 @@ jobs:
             okapi-bridge-*.tar.gz.sha256
             capabilities.json
 
+      - name: Upload jar-with-dependencies (for v2 packaging)
+        uses: actions/upload-artifact@v7
+        with:
+          name: jar-${{ matrix.okapi-version }}
+          path: okapi-releases/${{ matrix.okapi-version }}/target/neokapi-bridge-*-jar-with-dependencies.jar
+
+  package-v2:
+    # Mode-C plugin tarballs per (okapi-version, os, arch). Each tarball
+    # bundles the Go shim + the JAR + a Temurin JRE matching the bridge's
+    # required Java version (11 or 17, from okapi-releases/<v>/meta.json).
+    if: github.event_name == 'push'
+    needs: [setup, build]
+    strategy:
+      fail-fast: false
+      matrix:
+        okapi-version: ${{ fromJson(needs.setup.outputs.versions) }}
+        target:
+          - { os: linux,   arch: amd64, runner: ubuntu-latest }
+          - { os: linux,   arch: arm64, runner: ubuntu-latest }
+          - { os: darwin,  arch: amd64, runner: macos-latest }
+          - { os: darwin,  arch: arm64, runner: macos-latest }
+    runs-on: ${{ matrix.target.runner }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.23'
+
+      - name: Set up Java (host JRE for filter introspection)
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Download JAR for ${{ matrix.okapi-version }}
+        uses: actions/download-artifact@v8
+        with:
+          name: jar-${{ matrix.okapi-version }}
+          path: okapi-releases/${{ matrix.okapi-version }}/target/
+
+      - name: Build v2 plugin tarball
+        env:
+          OKAPI_VERSION: ${{ matrix.okapi-version }}
+          TARGET_OS: ${{ matrix.target.os }}
+          TARGET_ARCH: ${{ matrix.target.arch }}
+        run: |
+          ./scripts/package-release-v2.sh \
+            --okapi-version "$OKAPI_VERSION" \
+            --os "$TARGET_OS" \
+            --arch "$TARGET_ARCH" \
+            --bundle-jre
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Cosign sign-blob (keyless)
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          for tarball in dist/v2/*.tar.gz; do
+            cosign sign-blob --yes \
+              --output-signature "${tarball}.sig" \
+              --output-certificate "${tarball}.pem" \
+              "${tarball}"
+          done
+
+      - name: Upload v2 plugin artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: v2-${{ matrix.okapi-version }}-${{ matrix.target.os }}-${{ matrix.target.arch }}
+          path: |
+            dist/v2/*.tar.gz
+            dist/v2/*.tar.gz.sha256
+            dist/v2/*.sig
+            dist/v2/*.pem
+
   release:
-    needs: build
-    if: always() && !cancelled() && github.event_name == 'push'
+    needs: [build, package-v2]
+    # package-v2 may fail for one platform without blocking the release —
+    # any v2 tarballs that exist will still be uploaded.
+    if: always() && !cancelled() && github.event_name == 'push' && needs.build.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -198,6 +279,10 @@ jobs:
           files: |
             artifacts/okapi-bridge-*.tar.gz
             artifacts/okapi-bridge-*.tar.gz.sha256
+            artifacts/kapi-okapi-bridge_*.tar.gz
+            artifacts/kapi-okapi-bridge_*.tar.gz.sha256
+            artifacts/kapi-okapi-bridge_*.tar.gz.sig
+            artifacts/kapi-okapi-bridge_*.tar.gz.pem
           generate_release_notes: true
 
   publish-testdata:

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,12 @@
 
 SHELL := /bin/bash
 .PHONY: help list-upstream list-local add-release regenerate regenerate-all \
-        version-schemas build clean test generate-pom generate-all-poms \
+        version-schemas build clean test test-go generate-pom generate-all-poms \
         centralize regenerate-composites build-tools \
         download-filter-docs parse-filter-docs parse-filter-docs-force \
         bundle-filter-docs clean-filter-docs snapshot \
         verify-schemas update-readme-matrix \
-        assemble transform plugin \
+        assemble transform plugin plugin-v2 \
         release release-prepare release-perform
 
 # Configuration - derived from okapi-releases directory
@@ -34,13 +34,15 @@ help:
 	@echo "Plugin Pipeline:"
 	@echo "  make assemble V=1.47.0    Assemble okapi-data/ (pure Okapi vocabulary)"
 	@echo "  make transform V=1.47.0   Transform to neokapi plugin format (dist/plugin/)"
-	@echo "  make plugin V=1.47.0      Full pipeline: assemble + transform"
+	@echo "  make plugin V=1.47.0      Full pipeline: assemble + transform (legacy v1)"
+	@echo "  make plugin-v2 V=1.47.0   Build v2 manifest-driven plugin tarball (host platform)"
 	@echo ""
 	@echo "Build:"
 	@echo "  make build V=1.47.0       Build JAR for specific Okapi version"
 	@echo "  make snapshot V=1.49.0-SNAPSHOT  Build against locally-installed Okapi"
 	@echo "  make build-tools          Build schema generator tools (Java 17)"
-	@echo "  make test                 Run tests (bridge-core)"
+	@echo "  make test                 Run all tests (bridge-core + Go shim/manifest-gen)"
+	@echo "  make test-go              Run only Go tests (cmd/shim, cmd/manifest-gen)"
 	@echo "  make clean                Clean build artifacts"
 	@echo ""
 	@echo "Documentation:"
@@ -243,9 +245,27 @@ endif
 	echo "Built: $$(ls $$SNAPSHOT_DIR/target/neokapi-bridge-*-jar-with-dependencies.jar)" && \
 	echo "Test:  mvn -B test -pl bridge-core -Dokapi.version=$(V)"
 
-test:
+test: test-go
 	@echo "Running tests (bridge-core against Okapi $(LATEST_VERSION))..."
 	@mvn -B test -pl bridge-core -Dokapi.version=$(LATEST_VERSION)
+
+# Run Go unit tests for the shim and manifest-gen.
+test-go:
+	@echo "Running Go tests..."
+	@go test ./...
+
+# Build the v2 plugin tarball for the host platform (mode-c manifest-driven).
+# Requires `make build V=...` to have produced the JAR first.
+plugin-v2:
+ifndef V
+	$(error V is required. Usage: make plugin-v2 V=1.47.0)
+endif
+	@host_os=$$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/darwin/;s/linux/linux/'); \
+	host_arch=$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/'); \
+	./scripts/package-release-v2.sh \
+	    --okapi-version $(V) \
+	    --os $$host_os \
+	    --arch $$host_arch
 
 clean:
 	@mvn -B clean 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ The composite version increments when either the base schema OR the override cha
 ### Schema Statistics
 
 - **Total filters**: 57
-- **Total schema versions**: 123
-- **Filters with version changes**: 30
+- **Total schema versions**: 444
+- **Filters with version changes**: 49
 
 ### Schema Version Matrix
 
@@ -127,6 +127,7 @@ Only filters with multiple versions are shown (`-` = filter not available).
 
 | Filter | 0.38 | 1.39.0 | 1.40.0 | 1.41.0 | 1.42.0 | 1.43.0 | 1.44.0 | 1.45.0 | 1.46.0 | 1.47.0 | 1.48.0 |
 |--------|------|------|------|------|------|------|------|------|------|------|------|
+| `okf_archive` | - | - | - | - | - | - | - | - | **v1** | v1 | v1 |
 | `okf_autoxliff` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | **v2** | v2 | v2 | v2 |
 | `okf_baseplaintext` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | **v2** | v2 | v2 |
 | `okf_basetable` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | **v2** | **v3** | v3 |
@@ -136,24 +137,42 @@ Only filters with multiple versions are shown (`-` = filter not available).
 | `okf_fixedwidthcolumns` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | **v2** | **v3** | v3 |
 | `okf_html` | **v1** | v1 | **v2** | v2 | **v3** | **v4** | v4 | **v5** | v5 | v5 | **v6** |
 | `okf_html5` | - | - | - | - | - | - | **v1** | v1 | v1 | v1 | **v2** |
+| `okf_icml` | - | - | - | - | - | - | - | - | **v1** | v1 | v1 |
 | `okf_idml` | - | - | - | - | - | - | **v1** | **v2** | **v3** | v3 | **v4** |
 | `okf_json` | **v1** | v1 | v1 | v1 | **v2** | v2 | v2 | v2 | **v3** | v3 | **v4** |
 | `okf_markdown` | **v1** | v1 | v1 | v1 | **v2** | **v3** | v3 | **v4** | v4 | v4 | v4 |
 | `okf_mif` | **v1** | **v2** | **v3** | **v4** | v4 | v4 | v4 | v4 | **v5** | v5 | v5 |
+| `okf_multiparsers` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 |
 | `okf_odf` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | **v2** | v2 | v2 |
 | `okf_openoffice` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | **v2** | v2 | v2 |
 | `okf_openxml` | **v1** | v1 | v1 | **v2** | v2 | **v3** | v3 | **v4** | **v5** | **v6** | **v7** |
 | `okf_paraplaintext` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | **v2** | v2 | v2 |
+| `okf_pdf` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | - |
+| `okf_phpcontent` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 |
 | `okf_plaintext` | **v1** | v1 | v1 | v1 | **v2** | v2 | v2 | v2 | v2 | v2 | **v3** |
 | `okf_po` | **v1** | v1 | v1 | **v2** | **v3** | v3 | v3 | v3 | v3 | v3 | v3 |
 | `okf_properties` | **v1** | v1 | **v2** | v2 | v2 | v2 | v2 | v2 | v2 | v2 | v2 |
+| `okf_rainbowkit` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 |
 | `okf_regex` | **v1** | **v2** | v2 | v2 | **v3** | **v4** | v4 | v4 | **v5** | v5 | v5 |
+| `okf_regexplaintext` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 |
+| `okf_rtf` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 |
+| `okf_sdlpackage` | - | - | - | - | - | - | - | - | **v1** | v1 | v1 |
 | `okf_splicedlines` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | **v2** | v2 | v2 |
 | `okf_table` | **v1** | v1 | v1 | v1 | **v2** | v2 | v2 | v2 | v2 | **v3** | **v4** |
 | `okf_tabseparatedvalues` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | **v2** | **v3** | **v4** |
 | `okf_tex` | **v2** | v2 | v2 | v2 | v2 | v2 | v2 | v2 | **v1** | v1 | v1 |
+| `okf_tmx` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 |
+| `okf_transifex` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 |
+| `okf_ts` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 |
+| `okf_ttml` | - | - | - | - | - | - | - | - | **v1** | v1 | - |
+| `okf_ttx` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 |
+| `okf_txml` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 |
+| `okf_vignette` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 |
+| `okf_vtt` | - | - | - | - | - | - | - | - | **v1** | v1 | - |
 | `okf_wiki` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | **v2** |
+| `okf_xini` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 | v1 |
 | `okf_xliff` | **v1** | **v2** | v2 | **v3** | **v4** | **v5** | v5 | v5 | **v6** | **v7** | **v8** |
+| `okf_xliff2` | - | - | - | - | - | - | - | - | - | **v1** | v1 |
 | `okf_xml` | **v1** | v1 | v1 | v1 | **v2** | v2 | v2 | v2 | v2 | **v3** | **v4** |
 | `okf_xmlstream` | **v1** | v1 | v1 | v1 | v1 | **v2** | v2 | v2 | v2 | v2 | v2 |
 | `okf_yaml` | **v1** | v1 | v1 | v1 | v1 | v1 | v1 | v1 | **v2** | v2 | v2 |

--- a/cmd/manifest-gen/main.go
+++ b/cmd/manifest-gen/main.go
@@ -1,0 +1,337 @@
+// Command manifest-gen produces a v2 manifest.json for the okapi-bridge
+// plugin (issue neokapi/neokapi#438). It reads the JSON output of the
+// bridge's `--list-filters` flag and emits a manifest declaring every Okapi
+// filter as a Mode-C format capability.
+//
+// Usage:
+//
+//	manifest-gen \
+//	  --okapi-version 1.47.0 \
+//	  --filters-json ./filters.json \
+//	  --plugin okapi-bridge \
+//	  --binary kapi-okapi-bridge \
+//	  --output ./manifest.json
+//
+// The schema of --filters-json is the JSON Gson dumps from
+// neokapi.bridge.model.FilterInfo via OkapiBridgeServer.listFiltersAndExit.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// FilterInfo mirrors neokapi.bridge.model.FilterInfo.
+type FilterInfo struct {
+	FilterClass string   `json:"filter_class"`
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	DisplayName string   `json:"display_name"`
+	MimeTypes   []string `json:"mime_types"`
+	Extensions  []string `json:"extensions"`
+	// Capabilities lists supported operations: "read", "write".
+	// FilterRegistry sets these per-filter; missing means "read","write" both
+	// (the historical default).
+	Capabilities []string `json:"capabilities"`
+}
+
+// ListFiltersOutput is the top-level JSON shape from --list-filters.
+type ListFiltersOutput struct {
+	Filters []FilterInfo `json:"filters"`
+}
+
+// Manifest is the v2 manifest.json. We define a local Manifest type rather
+// than depending on neokapi to keep this generator self-contained.
+//
+// See neokapi/core/plugin/manifest/manifest.go for the canonical Go types.
+type Manifest struct {
+	ManifestVersion string         `json:"manifest_version"`
+	Plugin          string         `json:"plugin"`
+	Version         string         `json:"version"`
+	Description     string         `json:"description,omitempty"`
+	Homepage        string         `json:"homepage,omitempty"`
+	Author          string         `json:"author,omitempty"`
+	License         string         `json:"license,omitempty"`
+	Binary          string         `json:"binary"`
+	MinKapiVersion  string         `json:"min_kapi_version,omitempty"`
+	Group           string         `json:"group,omitempty"`
+	Capabilities    Capabilities   `json:"capabilities"`
+	Daemon          *DaemonConfig  `json:"daemon,omitempty"`
+}
+
+// Capabilities groups capability sections. We only populate Formats here.
+type Capabilities struct {
+	Formats []Format `json:"formats,omitempty"`
+}
+
+// Format declares one format reader/writer.
+type Format struct {
+	Name         string   `json:"name"`
+	DisplayName  string   `json:"display_name,omitempty"`
+	Description  string   `json:"description,omitempty"`
+	Extensions   []string `json:"extensions,omitempty"`
+	MimeTypes    []string `json:"mime_types,omitempty"`
+	Capabilities []string `json:"capabilities,omitempty"`
+	Schema       string   `json:"schema,omitempty"`
+}
+
+// DaemonConfig declares Mode-C daemon behavior.
+type DaemonConfig struct {
+	IdleTimeoutSeconds    int       `json:"idle_timeout_seconds,omitempty"`
+	StartupTimeoutSeconds int       `json:"startup_timeout_seconds,omitempty"`
+	Handshake             *Handshake `json:"handshake,omitempty"`
+}
+
+// Handshake describes the daemon handshake protocol.
+type Handshake struct {
+	Type   string   `json:"type"`
+	Fields []string `json:"fields,omitempty"`
+}
+
+// skipFilters mirrors core/plugin/loader/loader.go: AutoXLIFFFilter is
+// a delegating meta-filter whose lifecycle confuses the bridge. Skip it.
+var skipFilters = map[string]bool{
+	"okf_autoxliff": true,
+}
+
+// Options drives Generate. Exposed as a struct so tests don't have to round-
+// trip via flags.
+type Options struct {
+	Plugin                string
+	Version               string
+	Binary                string
+	License               string
+	Description           string
+	Homepage              string
+	Author                string
+	Group                 string
+	MinKapiVersion        string
+	IdleTimeoutSeconds    int
+	StartupTimeoutSeconds int
+	SchemaPathPattern     string // e.g. "schemas/filters/composite/{id}.schema.json"; "" → empty
+	IncludeAutoXLIFF      bool   // for tests; production false
+}
+
+func main() {
+	var (
+		okapiVersion         = flag.String("okapi-version", "", "Okapi Framework version that this bridge bundles (required)")
+		filtersJSON          = flag.String("filters-json", "", "Path to OkapiBridgeServer --list-filters JSON output (required)")
+		output               = flag.String("output", "manifest.json", "Output path for manifest.json")
+		plugin               = flag.String("plugin", "okapi-bridge", "Plugin name (also used as install dir name)")
+		binary               = flag.String("binary", "kapi-okapi-bridge", "Plugin binary name (must match the shim binary inside the tarball)")
+		license              = flag.String("license", "Apache-2.0", "Plugin SPDX license id")
+		description          = flag.String("description", "Okapi Framework filters via gRPC bridge", "One-line description")
+		homepage             = flag.String("homepage", "https://github.com/neokapi/okapi-bridge", "Homepage URL")
+		author               = flag.String("author", "neokapi", "Plugin author")
+		group                = flag.String("group", "neokapi", "Logical plugin grouping")
+		minKapiVersion       = flag.String("min-kapi-version", "", "Minimum kapi version constraint, e.g. >=2.0.0")
+		idleTimeout          = flag.Int("idle-timeout", 300, "Daemon idle timeout in seconds")
+		startupTimeout       = flag.Int("startup-timeout", 30, "Daemon startup timeout in seconds")
+		schemaPathPattern    = flag.String("schema-path", "schemas/filters/composite/{id}.schema.json", "Path pattern (with {id} placeholder) for per-format schema files; pass an empty string to omit")
+	)
+	flag.Parse()
+
+	if *okapiVersion == "" {
+		dieUsage("--okapi-version is required")
+	}
+	if *filtersJSON == "" {
+		dieUsage("--filters-json is required")
+	}
+
+	raw, err := os.ReadFile(*filtersJSON)
+	if err != nil {
+		die(fmt.Errorf("read --filters-json: %w", err))
+	}
+
+	opts := Options{
+		Plugin:                *plugin,
+		Version:               *okapiVersion,
+		Binary:                *binary,
+		License:               *license,
+		Description:           *description,
+		Homepage:              *homepage,
+		Author:                *author,
+		Group:                 *group,
+		MinKapiVersion:        *minKapiVersion,
+		IdleTimeoutSeconds:    *idleTimeout,
+		StartupTimeoutSeconds: *startupTimeout,
+		SchemaPathPattern:     *schemaPathPattern,
+	}
+
+	manifest, err := Generate(raw, opts)
+	if err != nil {
+		die(err)
+	}
+
+	if err := writeJSON(*output, manifest); err != nil {
+		die(fmt.Errorf("write manifest: %w", err))
+	}
+}
+
+// Generate parses the --list-filters JSON and produces a manifest using opts.
+func Generate(filtersJSON []byte, opts Options) (*Manifest, error) {
+	if opts.Plugin == "" {
+		return nil, errors.New("plugin name required")
+	}
+	if opts.Version == "" {
+		return nil, errors.New("plugin version required")
+	}
+	if opts.Binary == "" {
+		return nil, errors.New("plugin binary required")
+	}
+
+	var listed ListFiltersOutput
+	if err := json.Unmarshal(filtersJSON, &listed); err != nil {
+		return nil, fmt.Errorf("parse filters JSON: %w", err)
+	}
+
+	formats := make([]Format, 0, len(listed.Filters))
+	for _, f := range listed.Filters {
+		if !opts.IncludeAutoXLIFF && skipFilters[f.ID] {
+			continue
+		}
+		if f.ID == "" {
+			continue
+		}
+		formats = append(formats, Format{
+			Name:         f.ID,
+			DisplayName:  pickDisplayName(f),
+			Extensions:   normalizeExtensions(f.Extensions),
+			MimeTypes:    dedupeStrings(f.MimeTypes),
+			Capabilities: pickCapabilities(f.Capabilities),
+			Schema:       expandSchemaPath(opts.SchemaPathPattern, f.ID),
+		})
+	}
+	// Stable order so identical inputs produce identical output (helps CI
+	// avoid spurious diffs).
+	sort.SliceStable(formats, func(i, j int) bool { return formats[i].Name < formats[j].Name })
+
+	return &Manifest{
+		ManifestVersion: "1",
+		Plugin:          opts.Plugin,
+		Version:         opts.Version,
+		Description:     opts.Description,
+		Homepage:        opts.Homepage,
+		Author:          opts.Author,
+		License:         opts.License,
+		Binary:          opts.Binary,
+		Group:           opts.Group,
+		MinKapiVersion:  opts.MinKapiVersion,
+		Capabilities:    Capabilities{Formats: formats},
+		Daemon: &DaemonConfig{
+			IdleTimeoutSeconds:    opts.IdleTimeoutSeconds,
+			StartupTimeoutSeconds: opts.StartupTimeoutSeconds,
+			Handshake: &Handshake{
+				Type:   "stdio-handshake",
+				Fields: []string{"socket", "version"},
+			},
+		},
+	}, nil
+}
+
+// pickDisplayName returns the display_name when present, else the name, else
+// the id.
+func pickDisplayName(f FilterInfo) string {
+	if f.DisplayName != "" {
+		return f.DisplayName
+	}
+	if f.Name != "" {
+		return f.Name
+	}
+	return f.ID
+}
+
+// pickCapabilities returns the filter's declared capabilities, or the
+// historical default ["read","write"] when missing.
+func pickCapabilities(caps []string) []string {
+	if len(caps) == 0 {
+		return []string{"read", "write"}
+	}
+	return dedupeStrings(caps)
+}
+
+// normalizeExtensions trims whitespace and normalizes leading dots so each
+// returned extension starts with exactly one ".". Empty strings are dropped.
+func normalizeExtensions(exts []string) []string {
+	if len(exts) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(exts))
+	out := make([]string, 0, len(exts))
+	for _, raw := range exts {
+		ext := strings.TrimSpace(raw)
+		if ext == "" {
+			continue
+		}
+		if !strings.HasPrefix(ext, ".") {
+			ext = "." + ext
+		}
+		if _, ok := seen[ext]; ok {
+			continue
+		}
+		seen[ext] = struct{}{}
+		out = append(out, ext)
+	}
+	return out
+}
+
+// dedupeStrings removes empty entries and duplicates while preserving order.
+func dedupeStrings(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+// expandSchemaPath substitutes {id} in pattern with id. Empty pattern returns
+// "" so the manifest field is omitted.
+func expandSchemaPath(pattern, id string) string {
+	if pattern == "" {
+		return ""
+	}
+	return strings.ReplaceAll(pattern, "{id}", id)
+}
+
+func writeJSON(path string, m *Manifest) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(m); err != nil {
+		return err
+	}
+	return nil
+}
+
+func dieUsage(msg string) {
+	fmt.Fprintln(os.Stderr, "manifest-gen:", msg)
+	flag.CommandLine.SetOutput(os.Stderr)
+	flag.Usage()
+	os.Exit(2)
+}
+
+func die(err error) {
+	fmt.Fprintln(os.Stderr, "manifest-gen:", err)
+	os.Exit(1)
+}

--- a/cmd/manifest-gen/main_test.go
+++ b/cmd/manifest-gen/main_test.go
@@ -1,0 +1,259 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeExtensions(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   []string
+		want []string
+	}{
+		{nil, nil},
+		{[]string{}, nil},
+		{[]string{"html", ".htm"}, []string{".html", ".htm"}},
+		{[]string{".idml", " .idml ", ""}, []string{".idml"}},
+		{[]string{".xliff", ".xlf", ".xliff"}, []string{".xliff", ".xlf"}},
+	}
+	for _, tc := range cases {
+		got := normalizeExtensions(tc.in)
+		if !sliceEq(got, tc.want) {
+			t.Errorf("normalizeExtensions(%v) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestPickCapabilities(t *testing.T) {
+	t.Parallel()
+	got := pickCapabilities(nil)
+	if !sliceEq(got, []string{"read", "write"}) {
+		t.Errorf("default = %v", got)
+	}
+	got = pickCapabilities([]string{"read"})
+	if !sliceEq(got, []string{"read"}) {
+		t.Errorf("explicit read-only = %v", got)
+	}
+	got = pickCapabilities([]string{"read", "read", "write"})
+	if !sliceEq(got, []string{"read", "write"}) {
+		t.Errorf("dedupe = %v", got)
+	}
+}
+
+func TestExpandSchemaPath(t *testing.T) {
+	t.Parallel()
+	if expandSchemaPath("", "okf_html") != "" {
+		t.Errorf("empty pattern should yield empty path")
+	}
+	got := expandSchemaPath("schemas/{id}.json", "okf_html")
+	if got != "schemas/okf_html.json" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestGenerate_Shape(t *testing.T) {
+	t.Parallel()
+	input := `{
+		"filters": [
+			{
+				"filter_class": "net.sf.okapi.filters.html.HtmlFilter",
+				"id": "okf_html",
+				"name": "okf_html",
+				"display_name": "HTML Filter",
+				"mime_types": ["text/html"],
+				"extensions": [".html", ".htm"],
+				"capabilities": ["read", "write"]
+			},
+			{
+				"filter_class": "net.sf.okapi.filters.json.JSONFilter",
+				"id": "okf_json",
+				"name": "okf_json",
+				"display_name": "JSON Filter",
+				"mime_types": ["application/json"],
+				"extensions": ["json"],
+				"capabilities": null
+			},
+			{
+				"id": "okf_autoxliff",
+				"name": "okf_autoxliff",
+				"display_name": "Auto XLIFF",
+				"extensions": [".xlf", ".xliff"]
+			}
+		]
+	}`
+
+	m, err := Generate([]byte(input), Options{
+		Plugin:                "okapi-bridge",
+		Version:               "1.47.0",
+		Binary:                "kapi-okapi-bridge",
+		License:               "Apache-2.0",
+		Description:           "test",
+		Homepage:              "https://example.test",
+		Author:                "neokapi",
+		Group:                 "neokapi",
+		IdleTimeoutSeconds:    300,
+		StartupTimeoutSeconds: 30,
+		SchemaPathPattern:     "schemas/{id}.schema.json",
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if m.ManifestVersion != "1" {
+		t.Errorf("manifest_version = %q", m.ManifestVersion)
+	}
+	if m.Plugin != "okapi-bridge" || m.Version != "1.47.0" || m.Binary != "kapi-okapi-bridge" {
+		t.Errorf("identity wrong: %+v", m)
+	}
+	if m.Daemon == nil || m.Daemon.Handshake == nil {
+		t.Fatalf("daemon block missing")
+	}
+	if m.Daemon.Handshake.Type != "stdio-handshake" {
+		t.Errorf("handshake type %q", m.Daemon.Handshake.Type)
+	}
+	if !sliceEq(m.Daemon.Handshake.Fields, []string{"socket", "version"}) {
+		t.Errorf("handshake fields %v", m.Daemon.Handshake.Fields)
+	}
+	if m.Daemon.IdleTimeoutSeconds != 300 || m.Daemon.StartupTimeoutSeconds != 30 {
+		t.Errorf("daemon timeouts wrong: %+v", m.Daemon)
+	}
+
+	// okf_autoxliff must be filtered out by default.
+	if got := len(m.Capabilities.Formats); got != 2 {
+		t.Fatalf("expected 2 formats (autoxliff filtered), got %d: %+v", got, m.Capabilities.Formats)
+	}
+
+	// Stable ordering: alphabetical by Name.
+	if m.Capabilities.Formats[0].Name != "okf_html" || m.Capabilities.Formats[1].Name != "okf_json" {
+		t.Errorf("ordering wrong: %v / %v", m.Capabilities.Formats[0].Name, m.Capabilities.Formats[1].Name)
+	}
+
+	html := m.Capabilities.Formats[0]
+	if html.DisplayName != "HTML Filter" {
+		t.Errorf("display name = %q", html.DisplayName)
+	}
+	if !sliceEq(html.Extensions, []string{".html", ".htm"}) {
+		t.Errorf("extensions = %v", html.Extensions)
+	}
+	if !sliceEq(html.MimeTypes, []string{"text/html"}) {
+		t.Errorf("mime types = %v", html.MimeTypes)
+	}
+	if !sliceEq(html.Capabilities, []string{"read", "write"}) {
+		t.Errorf("capabilities = %v", html.Capabilities)
+	}
+	if html.Schema != "schemas/okf_html.schema.json" {
+		t.Errorf("schema path = %q", html.Schema)
+	}
+
+	// json filter: had nil capabilities → defaults to read+write; had bare
+	// "json" extension → normalized to ".json".
+	js := m.Capabilities.Formats[1]
+	if !sliceEq(js.Capabilities, []string{"read", "write"}) {
+		t.Errorf("json capabilities default = %v", js.Capabilities)
+	}
+	if !sliceEq(js.Extensions, []string{".json"}) {
+		t.Errorf("json extensions normalized = %v", js.Extensions)
+	}
+}
+
+func TestGenerate_RequiredFields(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		opts    Options
+		wantSub string
+	}{
+		{"no plugin", Options{Version: "1", Binary: "x"}, "plugin name"},
+		{"no version", Options{Plugin: "p", Binary: "x"}, "plugin version"},
+		{"no binary", Options{Plugin: "p", Version: "1"}, "plugin binary"},
+	}
+	for _, tc := range cases {
+		_, err := Generate([]byte(`{"filters":[]}`), tc.opts)
+		if err == nil || !strings.Contains(err.Error(), tc.wantSub) {
+			t.Errorf("%s: got %v, want substring %q", tc.name, err, tc.wantSub)
+		}
+	}
+}
+
+func TestGenerate_AllowAutoXLIFF(t *testing.T) {
+	t.Parallel()
+	input := `{"filters":[{"id":"okf_autoxliff","display_name":"Auto"}]}`
+	m, err := Generate([]byte(input), Options{
+		Plugin: "p", Version: "1", Binary: "b",
+		IncludeAutoXLIFF: true,
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(m.Capabilities.Formats) != 1 {
+		t.Fatalf("expected 1 format, got %d", len(m.Capabilities.Formats))
+	}
+}
+
+func TestGenerate_BadJSON(t *testing.T) {
+	t.Parallel()
+	_, err := Generate([]byte("not json"), Options{Plugin: "p", Version: "1", Binary: "b"})
+	if err == nil {
+		t.Fatalf("expected parse error")
+	}
+}
+
+func TestWriteJSON_Roundtrip(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manifest.json")
+
+	m := &Manifest{
+		ManifestVersion: "1",
+		Plugin:          "okapi-bridge",
+		Version:         "1.47.0",
+		Binary:          "kapi-okapi-bridge",
+		License:         "Apache-2.0",
+		Capabilities: Capabilities{
+			Formats: []Format{{Name: "okf_html", Capabilities: []string{"read"}}},
+		},
+		Daemon: &DaemonConfig{
+			IdleTimeoutSeconds:    300,
+			StartupTimeoutSeconds: 30,
+			Handshake: &Handshake{
+				Type:   "stdio-handshake",
+				Fields: []string{"socket", "version"},
+			},
+		},
+	}
+	if err := writeJSON(path, m); err != nil {
+		t.Fatalf("writeJSON: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	// Indented JSON should contain at least one newline.
+	if !strings.Contains(string(raw), "\n") {
+		t.Errorf("output not indented")
+	}
+
+	var got Manifest
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, raw)
+	}
+	if got.Plugin != "okapi-bridge" || got.Daemon == nil || got.Daemon.Handshake.Type != "stdio-handshake" {
+		t.Errorf("roundtrip mismatch: %+v", got)
+	}
+}
+
+func sliceEq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/shim/integration_test.go
+++ b/cmd/shim/integration_test.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDaemonHandshakeIntegration builds the shim, places it next to a
+// `jars/` dir containing the latest jar-with-dependencies, and checks that
+// `kapi-okapi-bridge daemon` emits a parsable handshake JSON line.
+//
+// Skipped when:
+//   - $OKAPI_BRIDGE_INTEGRATION is not "1" (lets CI opt in deliberately)
+//   - `java` is not on PATH (no JRE to run with)
+//   - no jar-with-dependencies is built under okapi-releases/*/target/
+func TestDaemonHandshakeIntegration(t *testing.T) {
+	if os.Getenv("OKAPI_BRIDGE_INTEGRATION") != "1" {
+		t.Skip("set OKAPI_BRIDGE_INTEGRATION=1 to run")
+	}
+	if _, err := exec.LookPath("java"); err != nil {
+		t.Skip("java not on PATH")
+	}
+
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		t.Skipf("repo root not found: %v", err)
+	}
+
+	jar, err := newestJar(filepath.Join(repoRoot, "okapi-releases"))
+	if err != nil {
+		t.Skipf("no jar-with-dependencies built; run `make build V=...` first: %v", err)
+	}
+
+	// Build the shim into a tempdir laid out as the v2 tarball expects.
+	stage := t.TempDir()
+	jarDir := filepath.Join(stage, "jars")
+	if err := os.MkdirAll(jarDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	stagedJar := filepath.Join(jarDir, "neokapi-bridge-jar-with-dependencies.jar")
+	if err := copyFile(jar, stagedJar); err != nil {
+		t.Fatalf("copy jar: %v", err)
+	}
+
+	shimBin := filepath.Join(stage, "kapi-okapi-bridge")
+	build := exec.Command("go", "build",
+		"-o", shimBin,
+		"-ldflags", "-X main.Version=integration-test",
+		"./cmd/shim",
+	)
+	build.Dir = repoRoot
+	build.Stderr = os.Stderr
+	build.Stdout = os.Stderr
+	if err := build.Run(); err != nil {
+		t.Fatalf("build shim: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, shimBin, "daemon")
+	cmd.Stderr = os.Stderr
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	// Read the first line only — that's the handshake.
+	br := newLineReader(stdout)
+	line, err := br.readLineWithin(45 * time.Second)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatalf("read handshake line: %v", err)
+	}
+	t.Logf("handshake line: %s", line)
+
+	var hs handshakePayload
+	if err := json.Unmarshal([]byte(strings.TrimSpace(line)), &hs); err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatalf("handshake not JSON: %v: %q", err, line)
+	}
+	if hs.Version != "integration-test" {
+		t.Errorf("version = %q, want integration-test", hs.Version)
+	}
+	if hs.Socket == "" {
+		t.Errorf("socket empty")
+	} else if _, err := os.Stat(hs.Socket); err != nil {
+		t.Errorf("socket %q not present: %v", hs.Socket, err)
+	}
+
+	// Drain stdout so the JVM doesn't block on a full pipe.
+	go io.Copy(io.Discard, stdout)
+
+	// Send SIGTERM and ensure the shim exits cleanly within a few seconds.
+	if err := cmd.Process.Signal(os.Interrupt); err != nil {
+		t.Fatalf("interrupt: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			var ee *exec.ExitError
+			if errors.As(err, &ee) {
+				// Signaled exits are acceptable.
+				return
+			}
+			t.Errorf("shim wait: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Errorf("shim did not exit within 15s of SIGINT")
+	}
+
+	// Socket file should be cleaned up.
+	if _, err := os.Stat(hs.Socket); err == nil {
+		t.Errorf("socket %q not cleaned up after exit", hs.Socket)
+	}
+}
+
+// findRepoRoot walks up from the current working directory looking for go.mod.
+func findRepoRoot() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(wd, "go.mod")); err == nil {
+			return wd, nil
+		}
+		parent := filepath.Dir(wd)
+		if parent == wd {
+			return "", errors.New("no go.mod ancestor")
+		}
+		wd = parent
+	}
+}
+
+// newestJar returns the newest path matching okapi-releases/*/target/
+// neokapi-bridge-*-jar-with-dependencies.jar.
+func newestJar(releasesDir string) (string, error) {
+	matches, _ := filepath.Glob(filepath.Join(releasesDir, "*", "target", "neokapi-bridge-*-jar-with-dependencies.jar"))
+	if len(matches) == 0 {
+		return "", errors.New("none found")
+	}
+	var newest string
+	var newestMtime time.Time
+	for _, m := range matches {
+		fi, err := os.Stat(m)
+		if err != nil {
+			continue
+		}
+		if fi.ModTime().After(newestMtime) {
+			newestMtime = fi.ModTime()
+			newest = m
+		}
+	}
+	if newest == "" {
+		return "", errors.New("no readable jar")
+	}
+	return newest, nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+// lineReader drains a reader one line at a time with timeouts so test
+// failures don't hang the suite forever.
+type lineReader struct {
+	r     io.Reader
+	buf   bytes.Buffer
+	chunk []byte
+}
+
+func newLineReader(r io.Reader) *lineReader {
+	return &lineReader{r: r, chunk: make([]byte, 1)}
+}
+
+func (lr *lineReader) readLineWithin(d time.Duration) (string, error) {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		n, err := lr.r.Read(lr.chunk)
+		if n > 0 {
+			b := lr.chunk[0]
+			if b == '\n' {
+				out := lr.buf.String()
+				lr.buf.Reset()
+				return out, nil
+			}
+			lr.buf.WriteByte(b)
+		}
+		if err != nil {
+			return lr.buf.String(), err
+		}
+	}
+	return lr.buf.String(), errors.New("deadline exceeded")
+}

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -1,0 +1,333 @@
+// Command kapi-okapi-bridge is the Go shim that fronts the Okapi Java bridge
+// in the v2 manifest-driven plugin model (issue neokapi/neokapi#438).
+//
+// kapi launches this binary as a Mode-C daemon. The shim is responsible for:
+//
+//  1. Locating a JRE (env override → bundled ./jre → $PATH).
+//  2. Picking a unique Unix-domain socket path under $TMPDIR.
+//  3. Spawning the JVM with NEOKAPI_BRIDGE_SOCKET set, classpath set to the
+//     bundled jar, and main class neokapi.bridge.OkapiBridgeServer.
+//  4. Reading the JVM's first stdout line — OkapiBridgeServer prints the
+//     socket address on the first line — and verifying it matches the path
+//     we requested.
+//  5. Emitting the v2 canonical handshake JSON line on the shim's own stdout:
+//     {"socket":"<path>","version":"<okapi-version>"}.
+//  6. Forwarding the JVM's remaining stdout/stderr to the shim's stdout/stderr
+//     so kapi sees subsequent log output.
+//  7. Waiting for SIGTERM/SIGINT (or for the JVM to exit), then cleaning up
+//     the socket file.
+//
+// Subcommands:
+//
+//	kapi-okapi-bridge daemon   — start the JVM and emit the handshake.
+//	kapi-okapi-bridge version  — print the bundled Okapi version.
+//	kapi-okapi-bridge --help   — print usage.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+)
+
+// Version is the bundled Okapi Framework version. Overridden at build time
+// with -ldflags "-X main.Version=<okapi-version>".
+var Version = "0.0.0-dev"
+
+// jarRelativePath is the path of the bundled jar relative to the directory
+// containing the shim binary.
+const jarRelativePath = "jars/neokapi-bridge-jar-with-dependencies.jar"
+
+// jvmMainClass is the FQCN of the bridge's main class inside the bundled jar.
+const jvmMainClass = "neokapi.bridge.OkapiBridgeServer"
+
+// startupBufBytes is the cap on bytes we will buffer when reading the JVM's
+// first line. Cheap defence against runaway output before the handshake.
+const startupBufBytes = 64 * 1024
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, "kapi-okapi-bridge:", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	if len(args) == 0 {
+		printUsage(os.Stderr)
+		return errors.New("missing subcommand")
+	}
+	switch args[0] {
+	case "daemon":
+		return runDaemon(args[1:])
+	case "version", "--version", "-v":
+		fmt.Println(Version)
+		return nil
+	case "help", "--help", "-h":
+		printUsage(os.Stdout)
+		return nil
+	default:
+		printUsage(os.Stderr)
+		return fmt.Errorf("unknown subcommand %q", args[0])
+	}
+}
+
+func printUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage: kapi-okapi-bridge <subcommand>")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Subcommands:")
+	fmt.Fprintln(w, "  daemon    Start the bridge JVM and emit a Mode-C handshake on stdout.")
+	fmt.Fprintln(w, "  version   Print the bundled Okapi version.")
+	fmt.Fprintln(w, "  help      Print this message.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Environment:")
+	fmt.Fprintln(w, "  NEOKAPI_JRE_HOME   Override JRE root directory (expects bin/java inside).")
+	fmt.Fprintln(w, "  NEOKAPI_BRIDGE_SOCKET")
+	fmt.Fprintln(w, "                     Override the Unix-socket path the JVM will bind.")
+	fmt.Fprintln(w, "  KAPI_BRIDGE_HEAP   JVM max heap (e.g. 8g). Default: 16g.")
+}
+
+// runDaemon implements the `daemon` subcommand.
+func runDaemon(_ []string) error {
+	binDir, err := executableDir()
+	if err != nil {
+		return fmt.Errorf("locate self: %w", err)
+	}
+
+	javaBin, err := findJava(binDir, lookupEnv, statFile, lookPath)
+	if err != nil {
+		return err
+	}
+
+	jarPath := filepath.Join(binDir, jarRelativePath)
+	if _, err := statFile(jarPath); err != nil {
+		return fmt.Errorf("bundled jar not found at %s: %w", jarPath, err)
+	}
+
+	socketPath := os.Getenv("NEOKAPI_BRIDGE_SOCKET")
+	if socketPath == "" {
+		socketPath = defaultSocketPath(os.Getpid())
+	}
+
+	// Best-effort: remove any stale socket left over from a previous crash.
+	_ = os.Remove(socketPath)
+
+	heap := os.Getenv("KAPI_BRIDGE_HEAP")
+	if heap == "" {
+		heap = "16g"
+	}
+
+	jvmArgs := []string{
+		"-Xmx" + heap,
+		// Without this, DefaultChannelId init takes ~5s on macOS.
+		"-Dio.netty.machineId=00:00:00:00:00:01",
+		"-cp", jarPath,
+		jvmMainClass,
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, javaBin, jvmArgs...)
+	cmd.Env = append(os.Environ(), "NEOKAPI_BRIDGE_SOCKET="+socketPath)
+	cmd.Stderr = os.Stderr // forward JVM stderr verbatim
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("pipe jvm stdout: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start jvm: %w", err)
+	}
+
+	// Read the JVM's first stdout line — OkapiBridgeServer.main writes the
+	// socket address on a single line and flushes before continuing.
+	jvmAnnounce, err := readFirstLine(stdout, startupBufBytes)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return fmt.Errorf("read jvm announce: %w", err)
+	}
+	jvmAnnounce = strings.TrimSpace(jvmAnnounce)
+	if jvmAnnounce != socketPath {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return fmt.Errorf("jvm announced socket %q, expected %q", jvmAnnounce, socketPath)
+	}
+
+	// Emit the v2 canonical handshake on the shim's stdout.
+	if err := writeHandshake(os.Stdout, socketPath, Version); err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return fmt.Errorf("write handshake: %w", err)
+	}
+
+	// Forward the rest of the JVM's stdout to ours. This is best-effort —
+	// when the JVM exits, the copy returns and we proceed to cleanup.
+	copyDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(os.Stdout, stdout)
+		close(copyDone)
+	}()
+
+	waitErr := cmd.Wait()
+	<-copyDone
+
+	// Always try to remove the socket file. Ignore errors — kapi may have
+	// removed it, or the JVM may have. Stale sockets are surprising but
+	// harmless because the path embeds our pid.
+	_ = os.Remove(socketPath)
+
+	if waitErr != nil {
+		// Context-cancelled exits look like signal-killed processes; treat
+		// those as clean shutdowns since we initiated them.
+		if ctx.Err() != nil {
+			return nil
+		}
+		var exitErr *exec.ExitError
+		if errors.As(waitErr, &exitErr) {
+			return fmt.Errorf("jvm exited %d", exitErr.ExitCode())
+		}
+		return fmt.Errorf("jvm wait: %w", waitErr)
+	}
+	return nil
+}
+
+// handshakePayload is the v2 canonical handshake JSON the shim emits on its
+// stdout's first line. The fields list is declared in manifest.json under
+// daemon.handshake.fields.
+type handshakePayload struct {
+	Socket  string `json:"socket"`
+	Version string `json:"version"`
+}
+
+func writeHandshake(w io.Writer, socket, version string) error {
+	payload, err := json.Marshal(handshakePayload{Socket: socket, Version: version})
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(payload); err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte{'\n'}); err != nil {
+		return err
+	}
+	if f, ok := w.(*os.File); ok {
+		_ = f.Sync()
+	}
+	return nil
+}
+
+// readFirstLine reads up to a newline from r, capped at maxBytes. Returns
+// the line without its trailing newline.
+func readFirstLine(r io.Reader, maxBytes int) (string, error) {
+	buf := make([]byte, 0, 256)
+	one := make([]byte, 1)
+	for len(buf) < maxBytes {
+		n, err := r.Read(one)
+		if n == 1 {
+			if one[0] == '\n' {
+				return string(buf), nil
+			}
+			buf = append(buf, one[0])
+		}
+		if err != nil {
+			if err == io.EOF && len(buf) > 0 {
+				return string(buf), nil
+			}
+			return string(buf), err
+		}
+	}
+	return string(buf), fmt.Errorf("first line exceeded %d bytes", maxBytes)
+}
+
+// defaultSocketPath builds a per-PID Unix-socket path under $TMPDIR. The path
+// must stay under the kernel's sun_path limit (104 on macOS, 108 on Linux),
+// so we keep the basename short.
+func defaultSocketPath(pid int) string {
+	dir := os.Getenv("TMPDIR")
+	if dir == "" {
+		dir = os.TempDir()
+	}
+	// Trim trailing slash that some platforms add to TMPDIR.
+	dir = strings.TrimRight(dir, string(os.PathSeparator))
+	return filepath.Join(dir, fmt.Sprintf("kob-%d.sock", pid))
+}
+
+// executableDir returns the directory holding the running binary, resolving
+// any symlinks. Used to anchor lookups for the bundled JRE and jar.
+func executableDir() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		// EvalSymlinks fails on some Go test binaries; fall back to the
+		// raw path which is fine when there is no symlink in the chain.
+		resolved = exe
+	}
+	return filepath.Dir(resolved), nil
+}
+
+// findJava resolves the JRE binary path. Resolution order:
+//
+//  1. NEOKAPI_JRE_HOME (expects bin/java inside).
+//  2. <binDir>/jre/bin/java — bundled JRE shipped alongside the shim.
+//  3. JAVA_HOME (expects bin/java inside).
+//  4. java on PATH.
+//
+// The lookupEnv, stat and lookPath functions are injected to make the
+// resolver testable.
+func findJava(
+	binDir string,
+	getenv func(string) string,
+	stat func(string) (os.FileInfo, error),
+	pathLookup func(string) (string, error),
+) (string, error) {
+	javaName := "java"
+	if runtime.GOOS == "windows" {
+		javaName = "java.exe"
+	}
+
+	if home := getenv("NEOKAPI_JRE_HOME"); home != "" {
+		candidate := filepath.Join(home, "bin", javaName)
+		if _, err := stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+
+	bundled := filepath.Join(binDir, "jre", "bin", javaName)
+	if _, err := stat(bundled); err == nil {
+		return bundled, nil
+	}
+
+	if home := getenv("JAVA_HOME"); home != "" {
+		candidate := filepath.Join(home, "bin", javaName)
+		if _, err := stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+
+	if path, err := pathLookup(javaName); err == nil {
+		return path, nil
+	}
+
+	return "", errors.New("no JRE found: set NEOKAPI_JRE_HOME, install a bundled jre/, set JAVA_HOME, or put java on PATH")
+}
+
+// lookupEnv, statFile and lookPath are the production wiring for findJava.
+// Tests substitute fakes.
+func lookupEnv(k string) string                  { return os.Getenv(k) }
+func statFile(p string) (os.FileInfo, error)     { return os.Stat(p) }
+func lookPath(name string) (string, error)       { return exec.LookPath(name) }

--- a/cmd/shim/main_test.go
+++ b/cmd/shim/main_test.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeFileInfo is a stand-in for os.FileInfo. We only need it for the not-nil
+// signal so the methods can stay no-ops.
+type fakeFileInfo struct{}
+
+func (fakeFileInfo) Name() string      { return "java" }
+func (fakeFileInfo) Size() int64       { return 0 }
+func (fakeFileInfo) Mode() os.FileMode { return 0 }
+func (fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (fakeFileInfo) IsDir() bool       { return false }
+func (fakeFileInfo) Sys() any          { return nil }
+
+// realStat is just a wrapper that satisfies the type while always erroring.
+// Tests construct their own fakeStat to drive the resolver.
+
+type findJavaCase struct {
+	name        string
+	env         map[string]string
+	existing    map[string]bool // file paths that "exist" for stat
+	pathFound   string          // result for exec.LookPath; "" → not found
+	pathErr     error           // err from exec.LookPath; only used when pathFound is ""
+	binDir      string
+	wantPath    string
+	wantErrSub  string // substring expected in error message; "" → expect no error
+}
+
+func TestFindJava(t *testing.T) {
+	t.Parallel()
+
+	cases := []findJavaCase{
+		{
+			name:     "NEOKAPI_JRE_HOME wins",
+			env:      map[string]string{"NEOKAPI_JRE_HOME": "/opt/myjre"},
+			existing: map[string]bool{"/opt/myjre/bin/java": true, "/install/jre/bin/java": true},
+			binDir:   "/install",
+			wantPath: "/opt/myjre/bin/java",
+		},
+		{
+			name:     "bundled jre falls through when env empty",
+			env:      map[string]string{},
+			existing: map[string]bool{"/install/jre/bin/java": true},
+			binDir:   "/install",
+			wantPath: "/install/jre/bin/java",
+		},
+		{
+			name:     "JAVA_HOME after bundled missing",
+			env:      map[string]string{"JAVA_HOME": "/sys/jdk"},
+			existing: map[string]bool{"/sys/jdk/bin/java": true},
+			binDir:   "/install",
+			wantPath: "/sys/jdk/bin/java",
+		},
+		{
+			name:      "PATH lookup last resort",
+			env:       map[string]string{},
+			existing:  map[string]bool{},
+			pathFound: "/usr/bin/java",
+			binDir:    "/install",
+			wantPath:  "/usr/bin/java",
+		},
+		{
+			name:       "all sources fail",
+			env:        map[string]string{},
+			existing:   map[string]bool{},
+			pathErr:    errors.New("not found"),
+			binDir:     "/install",
+			wantErrSub: "no JRE found",
+		},
+		{
+			name:     "NEOKAPI_JRE_HOME missing falls through to bundled",
+			env:      map[string]string{"NEOKAPI_JRE_HOME": "/nonexistent"},
+			existing: map[string]bool{"/install/jre/bin/java": true},
+			binDir:   "/install",
+			wantPath: "/install/jre/bin/java",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			getenv := func(k string) string { return tc.env[k] }
+			stat := func(p string) (os.FileInfo, error) {
+				if tc.existing[p] {
+					return fakeFileInfo{}, nil
+				}
+				return nil, os.ErrNotExist
+			}
+			lookPath := func(name string) (string, error) {
+				if tc.pathFound != "" {
+					return tc.pathFound, nil
+				}
+				if tc.pathErr != nil {
+					return "", tc.pathErr
+				}
+				return "", os.ErrNotExist
+			}
+			got, err := findJava(tc.binDir, getenv, stat, lookPath)
+			if tc.wantErrSub != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil (path %q)", tc.wantErrSub, got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrSub) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErrSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantPath {
+				t.Fatalf("got %q, want %q", got, tc.wantPath)
+			}
+		})
+	}
+}
+
+func TestWriteHandshake(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := writeHandshake(&buf, "/tmp/x.sock", "1.47.0"); err != nil {
+		t.Fatalf("writeHandshake: %v", err)
+	}
+	if !bytes.HasSuffix(buf.Bytes(), []byte{'\n'}) {
+		t.Fatalf("handshake must end with newline; got %q", buf.String())
+	}
+	var got handshakePayload
+	if err := json.Unmarshal(bytes.TrimRight(buf.Bytes(), "\n"), &got); err != nil {
+		t.Fatalf("unmarshal: %v\npayload: %s", err, buf.String())
+	}
+	if got.Socket != "/tmp/x.sock" {
+		t.Fatalf("socket: got %q want %q", got.Socket, "/tmp/x.sock")
+	}
+	if got.Version != "1.47.0" {
+		t.Fatalf("version: got %q want %q", got.Version, "1.47.0")
+	}
+}
+
+func TestReadFirstLine(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		input    string
+		max      int
+		wantLine string
+		wantErr  bool
+	}{
+		{"basic", "hello\nworld\n", 100, "hello", false},
+		{"only-line-no-newline-eof", "tail", 100, "tail", false},
+		{"empty-eof", "", 100, "", true},
+		{"exceeds-max", "abcdefghij", 4, "abcd", true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := readFirstLine(strings.NewReader(tc.input), tc.max)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err=%v wantErr=%v", err, tc.wantErr)
+			}
+			if got != tc.wantLine {
+				t.Fatalf("got %q want %q", got, tc.wantLine)
+			}
+		})
+	}
+}
+
+func TestRunArgvRouting(t *testing.T) {
+	cases := []struct {
+		name       string
+		args       []string
+		wantErrSub string
+	}{
+		{"no args", nil, "missing subcommand"},
+		{"unknown", []string{"frobnicate"}, "unknown subcommand"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := run(tc.args)
+			if tc.wantErrSub == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErrSub) {
+				t.Fatalf("got %v, want error containing %q", err, tc.wantErrSub)
+			}
+		})
+	}
+}
+
+func TestRunVersion(t *testing.T) {
+	// Capture stdout while calling run("version"). We use os.Pipe so we
+	// don't have to refactor run() to accept an io.Writer just for tests.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	saved := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = saved }()
+
+	prevVersion := Version
+	Version = "1.47.0-test"
+	defer func() { Version = prevVersion }()
+
+	done := make(chan error, 1)
+	go func() { done <- run([]string{"version"}) }()
+
+	if err := <-done; err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	_ = w.Close()
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "1.47.0-test" {
+		t.Fatalf("got %q want %q", string(out), "1.47.0-test")
+	}
+}
+
+func TestDefaultSocketPathShape(t *testing.T) {
+	customTmp := "/var/tmp/shim-test"
+	t.Setenv("TMPDIR", customTmp)
+	got := defaultSocketPath(12345)
+	if !strings.HasSuffix(got, "/kob-12345.sock") {
+		t.Fatalf("default socket path %q has unexpected suffix", got)
+	}
+	if !strings.HasPrefix(got, customTmp) {
+		t.Fatalf("default socket path %q does not honor TMPDIR=%q", got, customTmp)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/neokapi/okapi-bridge
+
+go 1.23

--- a/scripts/build-shim.sh
+++ b/scripts/build-shim.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Cross-compile the kapi-okapi-bridge Go shim for one (os, arch) combo.
+#
+# Usage:
+#   scripts/build-shim.sh \
+#     --os darwin --arch arm64 \
+#     --okapi-version 1.47.0 \
+#     --output ./stage/kapi-okapi-bridge
+#
+# The --okapi-version is embedded into the shim binary via -ldflags so
+# `kapi-okapi-bridge version` and the v2 handshake JSON line both report
+# the bundled Okapi Framework version.
+set -euo pipefail
+
+OS=""
+ARCH=""
+OKAPI_VERSION=""
+OUTPUT=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --os) OS="$2"; shift 2 ;;
+        --arch) ARCH="$2"; shift 2 ;;
+        --okapi-version) OKAPI_VERSION="$2"; shift 2 ;;
+        --output) OUTPUT="$2"; shift 2 ;;
+        *) echo "unknown flag: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ -z "$OS" || -z "$ARCH" || -z "$OKAPI_VERSION" || -z "$OUTPUT" ]]; then
+    echo "usage: $0 --os <linux|darwin|windows> --arch <amd64|arm64> --okapi-version <version> --output <path>" >&2
+    exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$ROOT_DIR"
+
+mkdir -p "$(dirname "$OUTPUT")"
+
+echo "build-shim: GOOS=$OS GOARCH=$ARCH version=$OKAPI_VERSION → $OUTPUT" >&2
+GOOS="$OS" GOARCH="$ARCH" CGO_ENABLED=0 \
+    go build \
+        -ldflags "-s -w -X main.Version=${OKAPI_VERSION}" \
+        -o "$OUTPUT" \
+        ./cmd/shim
+
+echo "build-shim: done $(file "$OUTPUT" | head -1)" >&2

--- a/scripts/bundle-jre.sh
+++ b/scripts/bundle-jre.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Download and stage a Temurin JRE for one (java-version, os, arch) combo.
+#
+# This is a shim helper used by package-release-v2.sh and CI. The JRE is
+# fetched from api.adoptium.net via the v3 "binary" endpoint, which 302s us
+# to the actual download URL.
+#
+# Usage:
+#   scripts/bundle-jre.sh \
+#     --java-version 11 \
+#     --os linux \
+#     --arch x64 \
+#     --output ./stage/jre
+#
+# Inputs:
+#   --java-version   11 | 17 (the only versions used by the bridge)
+#   --os             linux | mac | windows
+#   --arch           x64 | aarch64
+#   --output         destination directory (will contain bin/java after extraction)
+#   --image-type     jre (default) | jdk
+#
+# On success the output directory contains the extracted JRE root with
+# bin/java inside (no extra wrapper directory).
+#
+# Idempotent: if --output already contains bin/java, the script is a no-op.
+# Safe for repeated CI runs.
+set -euo pipefail
+
+JAVA_VERSION=""
+OS=""
+ARCH=""
+OUTPUT=""
+IMAGE_TYPE="jre"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --java-version) JAVA_VERSION="$2"; shift 2 ;;
+        --os) OS="$2"; shift 2 ;;
+        --arch) ARCH="$2"; shift 2 ;;
+        --output) OUTPUT="$2"; shift 2 ;;
+        --image-type) IMAGE_TYPE="$2"; shift 2 ;;
+        *) echo "unknown flag: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ -z "$JAVA_VERSION" || -z "$OS" || -z "$ARCH" || -z "$OUTPUT" ]]; then
+    echo "usage: $0 --java-version <11|17> --os <linux|mac|windows> --arch <x64|aarch64> --output <dir>" >&2
+    exit 2
+fi
+
+# Idempotency check.
+if [[ -x "$OUTPUT/bin/java" || -x "$OUTPUT/bin/java.exe" ]]; then
+    echo "bundle-jre: $OUTPUT already has bin/java; skipping download" >&2
+    exit 0
+fi
+
+mkdir -p "$OUTPUT"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+API_URL="https://api.adoptium.net/v3/binary/latest/${JAVA_VERSION}/ga/${OS}/${ARCH}/${IMAGE_TYPE}/hotspot/normal/eclipse"
+echo "bundle-jre: GET $API_URL" >&2
+
+# Adoptium 302s to the binary; -L follows.
+ARCHIVE="$TMP/archive"
+case "$OS" in
+    windows) ARCHIVE="$ARCHIVE.zip" ;;
+    *)       ARCHIVE="$ARCHIVE.tar.gz" ;;
+esac
+
+curl -fL --retry 3 --retry-delay 5 --connect-timeout 30 -o "$ARCHIVE" "$API_URL"
+
+echo "bundle-jre: extracting $(basename "$ARCHIVE") into $OUTPUT" >&2
+case "$OS" in
+    windows)
+        unzip -q "$ARCHIVE" -d "$TMP/extract"
+        ;;
+    *)
+        tar -xzf "$ARCHIVE" -C "$TMP/extract" || {
+            mkdir -p "$TMP/extract"
+            tar -xzf "$ARCHIVE" -C "$TMP/extract"
+        }
+        ;;
+esac
+
+# Adoptium archives wrap everything in a single jdk-* / jre-* directory.
+inner=$(find "$TMP/extract" -mindepth 1 -maxdepth 1 -type d | head -n1)
+if [[ -z "$inner" ]]; then
+    echo "bundle-jre: archive layout unexpected, no inner directory" >&2
+    exit 1
+fi
+
+# macOS Adoptium archives have a Contents/Home wrapper; flatten to the JRE root.
+if [[ -d "$inner/Contents/Home" ]]; then
+    inner="$inner/Contents/Home"
+fi
+
+# Copy into output.
+cp -R "$inner"/* "$OUTPUT"/
+
+if [[ ! -x "$OUTPUT/bin/java" && ! -x "$OUTPUT/bin/java.exe" ]]; then
+    echo "bundle-jre: extraction did not produce bin/java in $OUTPUT" >&2
+    exit 1
+fi
+
+echo "bundle-jre: ready: $OUTPUT/bin/java" >&2

--- a/scripts/centralize-schemas.sh
+++ b/scripts/centralize-schemas.sh
@@ -418,7 +418,11 @@ regenerate_composites() {
         else
             echo "  = $filter v$base_version (base only)"
         fi
-        ((composite_count++))
+        # NB: composite_count=$((... + 1)) (not ((composite_count++)))
+        # because under `set -e`, post-increment returns the *old* value
+        # and bash 4.4+ aborts when that is 0 (i.e. on first iteration).
+        # macOS bash 3.2 tolerates it, which is why this only fires in CI.
+        composite_count=$((composite_count + 1))
         done  # end base_files loop
     done  # end filters loop
 

--- a/scripts/package-release-v2.sh
+++ b/scripts/package-release-v2.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Package a v2 manifest-driven plugin tarball for one (okapi-version, os, arch).
+#
+# Layout produced:
+#
+#   kapi-okapi-bridge_<okapi-version>_<os>_<arch>.tar.gz
+#   └── okapi-bridge/
+#       ├── manifest.json
+#       ├── kapi-okapi-bridge        (Go shim, statically linked)
+#       ├── jars/
+#       │   └── neokapi-bridge-jar-with-dependencies.jar
+#       └── jre/                      (optional — bundled Temurin JRE)
+#           └── bin/java
+#
+# Inputs are passed via flags. The script does NOT build the JAR — it
+# expects okapi-releases/<okapi-version>/target/neokapi-bridge-*.jar
+# already exists (Maven step in the workflow runs first).
+#
+# Usage:
+#   scripts/package-release-v2.sh \
+#     --okapi-version 1.47.0 \
+#     --java-version 11 \
+#     --os linux --arch amd64 \
+#     --plugin okapi-bridge \
+#     [--bundle-jre] \
+#     [--no-tarball]
+#
+# Outputs:
+#   dist/v2/<plugin-name>-<okapi-version>-<os>-<arch>/  (staging dir)
+#   dist/v2/kapi-okapi-bridge_<okapi-version>_<os>_<arch>.tar.gz
+#
+# Maps Go GOOS/GOARCH → Adoptium os/arch:
+#   GOOS    Adoptium os
+#   linux   linux
+#   darwin  mac
+#   windows windows
+#   GOARCH  Adoptium arch
+#   amd64   x64
+#   arm64   aarch64
+set -euo pipefail
+
+OKAPI_VERSION=""
+JAVA_VERSION=""
+OS=""
+ARCH=""
+PLUGIN_NAME="okapi-bridge"
+BINARY_NAME="kapi-okapi-bridge"
+BUNDLE_JRE=0
+TARBALL=1
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --okapi-version) OKAPI_VERSION="$2"; shift 2 ;;
+        --java-version) JAVA_VERSION="$2"; shift 2 ;;
+        --os) OS="$2"; shift 2 ;;
+        --arch) ARCH="$2"; shift 2 ;;
+        --plugin) PLUGIN_NAME="$2"; shift 2 ;;
+        --binary) BINARY_NAME="$2"; shift 2 ;;
+        --bundle-jre) BUNDLE_JRE=1; shift ;;
+        --no-tarball) TARBALL=0; shift ;;
+        *) echo "unknown flag: $1" >&2; exit 2 ;;
+    esac
+done
+
+for required_flag in OKAPI_VERSION OS ARCH; do
+    if [[ -z "${!required_flag}" ]]; then
+        echo "missing required flag: --${required_flag,,}" >&2
+        exit 2
+    fi
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$ROOT_DIR"
+
+# Look up java-version from meta.json if not supplied.
+if [[ -z "$JAVA_VERSION" ]]; then
+    META="okapi-releases/${OKAPI_VERSION}/meta.json"
+    if [[ ! -f "$META" ]]; then
+        echo "package-release-v2: --java-version not supplied and $META missing" >&2
+        exit 1
+    fi
+    JAVA_VERSION=$(jq -r '.javaVersion' "$META")
+    if [[ "$JAVA_VERSION" == "null" || -z "$JAVA_VERSION" ]]; then
+        echo "package-release-v2: javaVersion missing from $META" >&2
+        exit 1
+    fi
+fi
+
+# Resolve GOOS/GOARCH → Adoptium taxonomy.
+case "$OS" in
+    linux)   ADOPTIUM_OS="linux" ;;
+    darwin)  ADOPTIUM_OS="mac" ;;
+    windows) ADOPTIUM_OS="windows" ;;
+    *) echo "unsupported --os $OS" >&2; exit 2 ;;
+esac
+case "$ARCH" in
+    amd64) ADOPTIUM_ARCH="x64" ;;
+    arm64) ADOPTIUM_ARCH="aarch64" ;;
+    *) echo "unsupported --arch $ARCH" >&2; exit 2 ;;
+esac
+
+JAR_DIR="okapi-releases/${OKAPI_VERSION}/target"
+JAR=$(ls "$JAR_DIR"/neokapi-bridge-*-jar-with-dependencies.jar 2>/dev/null | grep -v original- | head -n1 || true)
+if [[ -z "$JAR" ]]; then
+    echo "package-release-v2: no jar-with-dependencies in $JAR_DIR; build with 'make build V=$OKAPI_VERSION' first" >&2
+    exit 1
+fi
+
+STAGE_DIR="dist/v2/${PLUGIN_NAME}-${OKAPI_VERSION}-${OS}-${ARCH}/${PLUGIN_NAME}"
+rm -rf "$STAGE_DIR"
+mkdir -p "$STAGE_DIR/jars"
+
+# 1. Build the shim.
+SHIM_OUT="$STAGE_DIR/$BINARY_NAME"
+"$SCRIPT_DIR/build-shim.sh" \
+    --os "$OS" --arch "$ARCH" \
+    --okapi-version "$OKAPI_VERSION" \
+    --output "$SHIM_OUT"
+chmod +x "$SHIM_OUT"
+
+# 2. Stage the JAR.
+cp "$JAR" "$STAGE_DIR/jars/neokapi-bridge-jar-with-dependencies.jar"
+
+# 3. Generate the manifest from the live filter introspection.
+#    OkapiBridgeServer --list-filters runs against the host JRE, not the
+#    bundled one, so we just need any java on PATH that can load this jar.
+if ! command -v java >/dev/null 2>&1; then
+    echo "package-release-v2: java not on PATH; needed to introspect filters" >&2
+    exit 1
+fi
+
+FILTERS_JSON="$(mktemp)"
+trap 'rm -f "$FILTERS_JSON"' EXIT
+
+java -cp "$JAR" neokapi.bridge.OkapiBridgeServer --list-filters > "$FILTERS_JSON"
+
+go run ./cmd/manifest-gen \
+    --okapi-version "$OKAPI_VERSION" \
+    --filters-json "$FILTERS_JSON" \
+    --plugin "$PLUGIN_NAME" \
+    --binary "$BINARY_NAME" \
+    --output "$STAGE_DIR/manifest.json"
+
+# 4. Optionally bundle the JRE.
+if [[ "$BUNDLE_JRE" == "1" ]]; then
+    "$SCRIPT_DIR/bundle-jre.sh" \
+        --java-version "$JAVA_VERSION" \
+        --os "$ADOPTIUM_OS" \
+        --arch "$ADOPTIUM_ARCH" \
+        --output "$STAGE_DIR/jre"
+fi
+
+echo "package-release-v2: staged $STAGE_DIR" >&2
+
+# 5. Tarball.
+if [[ "$TARBALL" == "1" ]]; then
+    TARBALL_NAME="${BINARY_NAME}_${OKAPI_VERSION}_${OS}_${ARCH}.tar.gz"
+    TARBALL_PATH="dist/v2/$TARBALL_NAME"
+    rm -f "$TARBALL_PATH"
+    # Make the tar reproducible-ish: sorted, no owner/group metadata.
+    tar -C "$(dirname "$STAGE_DIR")" \
+        --no-xattrs \
+        --owner=0 --group=0 \
+        -czf "$TARBALL_PATH" \
+        "$PLUGIN_NAME" 2>/dev/null \
+        || tar -C "$(dirname "$STAGE_DIR")" -czf "$TARBALL_PATH" "$PLUGIN_NAME"
+
+    sha256sum "$TARBALL_PATH" > "$TARBALL_PATH.sha256" 2>/dev/null \
+        || shasum -a 256 "$TARBALL_PATH" > "$TARBALL_PATH.sha256"
+
+    echo "package-release-v2: wrote $TARBALL_PATH" >&2
+    echo "$TARBALL_PATH"
+fi


### PR DESCRIPTION
Phase 8 of the manifest-driven plugin model defined in [neokapi/neokapi#438](https://github.com/neokapi/neokapi/issues/438). Adds a Go shim, a manifest generator, and a parallel v2 release pipeline. The Java side is **untouched** — this is purely additive.

## Summary

- New `cmd/shim` (`kapi-okapi-bridge`) — a Go binary that fronts the JVM as a Mode-C daemon. Locates a JRE (env override → bundled `jre/` → `JAVA_HOME` → `PATH`), spawns the JVM with `NEOKAPI_BRIDGE_SOCKET` set, verifies the socket announce on the JVM's first stdout line, then prints the v2 canonical handshake JSON `{"socket":"…","version":"<okapi-version>"}` and forwards subsequent JVM stdout/stderr.
- New `cmd/manifest-gen` — generates a v2 `manifest.json` from the JSON output of `OkapiBridgeServer --list-filters`. Validates against neokapi's manifest validator (verified locally — all required fields present, declares Mode-C with `stdio-handshake`).
- New `scripts/build-shim.sh`, `scripts/bundle-jre.sh`, `scripts/package-release-v2.sh` — cross-compile the shim, fetch a Temurin JRE (Java 11 or 17 per `okapi-releases/<v>/meta.json`), and assemble + tarball as `kapi-okapi-bridge_<okapi>_<os>_<arch>.tar.gz`.
- `release.yml` — new `package-v2` matrix job per (okapi-version × {linux,darwin}×{amd64,arm64}) that signs each tarball with `cosign sign-blob --keyless` (Sigstore OIDC) and uploads tarballs + `.sig` + `.pem` to the GitHub Release.

## v2 tarball layout

```
kapi-okapi-bridge_1.47.0_darwin_arm64.tar.gz
└── okapi-bridge/
    ├── manifest.json                    # v2: declares formats[] + daemon block
    ├── kapi-okapi-bridge                # Go shim
    ├── jars/
    │   └── neokapi-bridge-jar-with-dependencies.jar
    └── jre/                             # bundled Temurin (~50MB)
        └── bin/java
```

## Platforms covered in this PR

- linux/amd64, linux/arm64
- darwin/amd64, darwin/arm64

**Windows is intentionally deferred.** The shim's TMPDIR/socket plumbing assumes POSIX paths and the bridge's daemon model uses Unix-domain sockets via Netty's KQueue/Epoll transports. Adding Windows needs a NamedPipe handshake path on both sides; tracked as a follow-up.

## Tests

- `go test ./...` — unit tests for argv routing, JRE discovery (mocked filesystem), handshake JSON serialization, manifest shape, capability inference, format-list ordering, ext normalization, JRE skip filter (`okf_autoxliff`).
- `cmd/shim/integration_test.go` — opt-in (`OKAPI_BRIDGE_INTEGRATION=1`) end-to-end that builds the shim, places it next to a real `jars/`, runs `kapi-okapi-bridge daemon`, and verifies the JSON handshake parses + the socket file appears + cleanup works on SIGTERM. Skipped unless `java` is on `PATH`.
- Verified locally: shim builds for `darwin/arm64`, `darwin/amd64`, `linux/amd64`, `linux/arm64`. `manifest-gen` output passes `manifest.Parse` from `neokapi/core/plugin/manifest` (Mode-C detected, all required fields populated).

## What's not included

- **Registry update for v2.** The existing `update-registry.sh` job continues to maintain the legacy `plugins.json`. Wiring `manifest-plugins.json` is left as a follow-up so the registry-side can be reviewed independently.
- **Removal of the legacy v1 packaging path.** Both pipelines run side-by-side until consumers have migrated; v1 keeps producing `okapi-bridge-v<version>-okapi<okapi-version>.tar.gz` exactly as before.
- **Windows tarballs** (see above).

## Test plan

- [ ] CI release build succeeds on a tag push and produces 4 v2 tarballs per Okapi version.
- [ ] Each tarball is cosign-signed and verifiable with `cosign verify-blob`.
- [ ] Installing one of the tarballs into kapi (per AD-014 layout) and running a format read/write round-trips correctly.
- [ ] Followup PR wires `manifest-plugins.json` in `neokapi/registry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)