### PR TITLE
config-by-name: apply a named Okapi filter config via ProcessHeader.config_id

### DIFF
--- a/bridge-core/src/main/java/neokapi/bridge/grpc/BridgeServiceImpl.java
+++ b/bridge-core/src/main/java/neokapi/bridge/grpc/BridgeServiceImpl.java
@@ -306,6 +306,11 @@ public class BridgeServiceImpl extends BridgeServiceGrpc.BridgeServiceImplBase {
                 return;
             }
 
+            // Apply a named built-in Okapi config first (e.g. okf_xml-resx),
+            // then layer any explicit filter_params override on top.
+            if (!header.getConfigId().isEmpty()) {
+                FilterRegistry.applyNamedConfig(filter, header.getConfigId());
+            }
             Map<String, String> filterParams = header.getFilterParamsMap();
             if (filterParams != null && !filterParams.isEmpty()) {
                 applyFilterParams(filter, filterParams);
@@ -589,6 +594,11 @@ public class BridgeServiceImpl extends BridgeServiceGrpc.BridgeServiceImplBase {
             throw new IllegalStateException(
                     "cannot instantiate filter on pass 2: " + effectiveFilterClass);
         }
+        // Named config first so the write pass uses the same config as the read
+        // pass; explicit filter_params override on top.
+        if (!header.getConfigId().isEmpty()) {
+            FilterRegistry.applyNamedConfig(f, header.getConfigId());
+        }
         Map<String, String> filterParams = header.getFilterParamsMap();
         if (filterParams != null && !filterParams.isEmpty()) {
             applyFilterParams(f, filterParams);
@@ -664,6 +674,11 @@ public class BridgeServiceImpl extends BridgeServiceGrpc.BridgeServiceImplBase {
             throw new IllegalStateException("cannot instantiate filter for write: " + effectiveFilterClass);
         }
 
+        // Named config first so the write path matches the read path; explicit
+        // filter_params override on top.
+        if (!header.getConfigId().isEmpty()) {
+            FilterRegistry.applyNamedConfig(writeFilter, header.getConfigId());
+        }
         Map<String, String> filterParams = header.getFilterParamsMap();
         if (filterParams != null && !filterParams.isEmpty()) {
             applyFilterParams(writeFilter, filterParams);

--- a/bridge-core/src/main/java/neokapi/bridge/util/FilterRegistry.java
+++ b/bridge-core/src/main/java/neokapi/bridge/util/FilterRegistry.java
@@ -279,10 +279,153 @@ public class FilterRegistry {
     }
 
     /**
+     * Apply a named built-in Okapi filter configuration to a live filter.
+     *
+     * <p>Finds the {@link FilterConfiguration} whose {@code configId} equals
+     * {@code configId} among {@code filter.getConfigurations()} — for compound
+     * filters (e.g. {@code XmlStreamFilter}, {@code XMLFilter}) this includes
+     * the built-in presets such as {@code okf_xmlstream-dita},
+     * {@code okf_xml-docbook} and {@code okf_xml-resx} — then loads that
+     * config's parameters from its {@code parametersLocation} resource (.fprm,
+     * .yml, ITS rules, …) and sets them on the filter.
+     *
+     * <p>The load uses Okapi's own {@code IParameters.load(URL, false)} so the
+     * native parameters type parses its native serialization (StringParameters
+     * #v1, YAML markup rules, ITS XML, …). The resource is resolved with the
+     * same multi-strategy lookup used for schema generation, since a few
+     * filters reference parameter files in a parent package.
+     *
+     * <p>Callers apply this BEFORE any explicit {@code filter_params} so that
+     * an explicit override layers on top of the named config's defaults.
+     *
+     * @param filter   a freshly-created filter instance
+     * @param configId the requested Okapi config id (e.g. "okf_xml-resx")
+     * @throws IllegalArgumentException if {@code configId} is unknown for the
+     *         filter (so a typo surfaces instead of silently using the default)
+     * @throws IllegalStateException if the config's parameter resource cannot
+     *         be resolved or loaded
+     */
+    public static void applyNamedConfig(IFilter filter, String configId) {
+        if (filter == null) {
+            throw new IllegalArgumentException("filter must not be null");
+        }
+        if (configId == null || configId.isEmpty()) {
+            throw new IllegalArgumentException("configId must not be empty");
+        }
+
+        List<FilterConfiguration> configs = filter.getConfigurations();
+        FilterConfiguration match = null;
+        List<String> known = new ArrayList<>();
+        if (configs != null) {
+            for (FilterConfiguration c : configs) {
+                if (c == null) {
+                    continue;
+                }
+                known.add(c.configId);
+                if (configId.equals(c.configId)) {
+                    match = c;
+                    break;
+                }
+            }
+        }
+
+        if (match == null) {
+            throw new IllegalArgumentException(
+                    "unknown filter configuration '" + configId + "' for "
+                            + filter.getClass().getName()
+                            + " (available: " + known + ")");
+        }
+
+        // The default/base config (e.g. okf_xml, okf_xmlstream) usually carries
+        // no parameter resource — the filter's default parameters already match
+        // it, so applying it is a no-op rather than an error.
+        if (match.parametersLocation == null || match.parametersLocation.isEmpty()) {
+            return;
+        }
+
+        URL resource = resolveConfigResourceURL(filter, match.parametersLocation);
+        if (resource == null) {
+            throw new IllegalStateException(
+                    "could not resolve parameters resource '" + match.parametersLocation
+                            + "' for config '" + configId + "' on "
+                            + filter.getClass().getName());
+        }
+
+        IParameters params = filter.getParameters();
+        if (params == null) {
+            throw new IllegalStateException(
+                    "filter " + filter.getClass().getName()
+                            + " does not support parameters; cannot apply config '" + configId + "'");
+        }
+
+        try {
+            // Okapi's canonical path: each IParameters implementation parses its
+            // own native serialization (StringParameters #v1, AbstractMarkup
+            // YAML, ITS rules XML, …). The boolean is ignoreErrors=false.
+            params.load(resource, false);
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    "failed to load parameters for config '" + configId + "' from "
+                            + resource + ": " + e.getMessage(), e);
+        }
+        filter.setParameters(params);
+        System.err.println("[bridge] Applied named config '" + configId + "' to "
+                + filter.getClass().getName() + " from " + match.parametersLocation);
+    }
+
+    /**
+     * Resolve a config's {@code parametersLocation} to a {@link URL} using the
+     * same multi-strategy lookup as {@link #loadParametersForConfig}. Filters
+     * normally reference a resource relative to the filter class, but a few
+     * (plaintext, table) reference files in a parent package.
+     */
+    private static URL resolveConfigResourceURL(IFilter filter, String parametersLocation) {
+        // Strategy 1: relative to filter class.
+        URL url = filter.getClass().getResource(parametersLocation);
+
+        // Strategy 2: classloader root with absolute path.
+        if (url == null) {
+            url = filter.getClass().getClassLoader().getResource(parametersLocation);
+        }
+
+        // Strategy 3: walk up the filter's package hierarchy.
+        if (url == null) {
+            String packagePath = filter.getClass().getPackage().getName().replace('.', '/');
+            while (url == null && packagePath.contains("/")) {
+                packagePath = packagePath.substring(0, packagePath.lastIndexOf('/'));
+                url = filter.getClass().getClassLoader().getResource(packagePath + "/" + parametersLocation);
+            }
+        }
+
+        // Strategy 4: common filter resource location.
+        if (url == null) {
+            String filterType = extractFilterType(filter.getClass().getName());
+            if (filterType != null) {
+                url = filter.getClass().getClassLoader().getResource(
+                        "net/sf/okapi/filters/" + filterType + "/" + parametersLocation);
+            }
+        }
+
+        // Strategy 5: plaintext package for okf_plaintext_* configs.
+        if (url == null && parametersLocation.startsWith("okf_plaintext")) {
+            url = filter.getClass().getClassLoader().getResource(
+                    "net/sf/okapi/filters/plaintext/" + parametersLocation);
+        }
+
+        // Strategy 6: table package for okf_table_* configs.
+        if (url == null && parametersLocation.startsWith("okf_table")) {
+            url = filter.getClass().getClassLoader().getResource(
+                    "net/sf/okapi/filters/table/" + parametersLocation);
+        }
+
+        return url;
+    }
+
+    /**
      * Load parameters from a classpath resource file (.yml or .fprm format).
      * Tries multiple resolution strategies since parameter files may be in parent packages.
      */
-    private static void loadParametersForConfig(IFilter filter, String parametersLocation, 
+    private static void loadParametersForConfig(IFilter filter, String parametersLocation,
                                                  FilterConfigurationInfo configInfo) {
         try {
             InputStream is = null;

--- a/bridge-core/src/main/proto/neokapi/bridge/v2/neokapi_bridge.proto
+++ b/bridge-core/src/main/proto/neokapi/bridge/v2/neokapi_bridge.proto
@@ -377,6 +377,13 @@ message ProcessHeader {
   repeated InlineStep inline_steps = 11; // Optional steps to run between filter and writer.
                                           // Steps are applied in order to each filter event
                                           // before it is streamed to Go or written to output.
+  string config_id = 12;             // Optional named Okapi filter configuration to apply
+                                     // before opening (e.g. "okf_xmlstream-dita",
+                                     // "okf_xml-docbook", "okf_xml-resx"). The bridge loads
+                                     // the config's built-in parameters (.fprm) and applies
+                                     // them; explicit filter_params override on top. Lets a
+                                     // config-preset format (DITA/DocBook/ResX) run
+                                     // head-to-head against its native xml-config preset.
 }
 
 // ProcessReadDone signals that all parts have been read from the document.

--- a/bridge-core/src/test/java/neokapi/bridge/util/ApplyNamedConfigTest.java
+++ b/bridge-core/src/test/java/neokapi/bridge/util/ApplyNamedConfigTest.java
@@ -1,0 +1,141 @@
+package neokapi.bridge.util;
+
+import net.sf.okapi.common.filters.IFilter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link FilterRegistry#applyNamedConfig} — loading a named built-in
+ * Okapi filter configuration onto a live filter (neokapi#613).
+ *
+ * <p>The compound XML filters expose their built-in presets via
+ * {@code getConfigurations()}. We assert that loading a specific preset sets
+ * parameters whose serialized form contains a rule distinctive to that preset's
+ * {@code .fprm} / {@code .yml} resource, and that an unknown configId errors
+ * (so a typo surfaces rather than silently using the filter's default config).
+ *
+ * <p>Config ids verified against Okapi 1.48.0:
+ * {@code okf_xml-resx} / {@code okf_xml-docbook} on
+ * {@code net.sf.okapi.filters.xml.XMLFilter} (its module) and
+ * {@code okf_xmlstream-dita} on
+ * {@code net.sf.okapi.filters.xmlstream.XmlStreamFilter}.
+ */
+class ApplyNamedConfigTest {
+
+    private static final String XML_FILTER = "net.sf.okapi.filters.xml.XMLFilter";
+    private static final String XMLSTREAM_FILTER = "net.sf.okapi.filters.xmlstream.XmlStreamFilter";
+
+    private static IFilter newFilter(String className) {
+        IFilter f = FilterRegistry.createFilter(className);
+        assertNotNull(f, "filter " + className + " must be on the classpath for this test");
+        return f;
+    }
+
+    // ── Known configs load distinctive parameters ───────────────────────────
+
+    @Test
+    void applyNamedConfig_resxOnXmlFilter_loadsResxItsRules() {
+        IFilter filter = newFilter(XML_FILTER);
+
+        FilterRegistry.applyNamedConfig(filter, "okf_xml-resx");
+
+        String params = filter.getParameters().toString();
+        assertNotNull(params);
+        // The RESX preset is ITS rules XML. Assert distinctive RESX selectors.
+        assertTrue(params.contains("its:rules"),
+                "RESX config should load ITS rules, got: " + params);
+        assertTrue(params.contains("$this.Text"),
+                "RESX config should contain the $this.Text translate rule, got: " + params);
+    }
+
+    @Test
+    void applyNamedConfig_docbookOnXmlFilter_loadsDocbookRules() {
+        IFilter filter = newFilter(XML_FILTER);
+
+        FilterRegistry.applyNamedConfig(filter, "okf_xml-docbook");
+
+        String params = filter.getParameters().toString();
+        assertNotNull(params);
+        assertTrue(params.contains("its:rules"),
+                "DocBook config should load ITS rules, got: " + params);
+        // DocBook rules reference docbook-specific elements (e.g. <para>).
+        assertTrue(params.toLowerCase().contains("para"),
+                "DocBook config should reference docbook elements, got: " + params);
+    }
+
+    @Test
+    void applyNamedConfig_ditaOnXmlStreamFilter_loadsDitaYaml() {
+        IFilter filter = newFilter(XMLSTREAM_FILTER);
+
+        FilterRegistry.applyNamedConfig(filter, "okf_xmlstream-dita");
+
+        String params = filter.getParameters().toString();
+        assertNotNull(params);
+        // The DITA preset is YAML markup rules. Assert distinctive DITA elements.
+        assertTrue(params.contains("topicref"),
+                "DITA config should reference the topicref element, got: " + params);
+        assertTrue(params.contains("navtitle"),
+                "DITA config should reference the navtitle attribute, got: " + params);
+    }
+
+    @Test
+    void applyNamedConfig_differsFromDefault() {
+        // The named config must actually change the filter's parameters away
+        // from its bare default — otherwise running a preset would be a no-op.
+        IFilter defaultFilter = newFilter(XMLSTREAM_FILTER);
+        String defaultParams = defaultFilter.getParameters().toString();
+
+        IFilter ditaFilter = newFilter(XMLSTREAM_FILTER);
+        FilterRegistry.applyNamedConfig(ditaFilter, "okf_xmlstream-dita");
+        String ditaParams = ditaFilter.getParameters().toString();
+
+        assertNotEquals(defaultParams, ditaParams,
+                "applying okf_xmlstream-dita should change parameters from the default config");
+    }
+
+    // ── Base config (no parameters resource) is a tolerated no-op ────────────
+
+    @Test
+    void applyNamedConfig_baseConfig_noParametersResource_isNoOp() {
+        IFilter filter = newFilter(XML_FILTER);
+        // okf_xml is the base config with a null parametersLocation — applying
+        // it must not throw (the filter's own defaults already match it).
+        assertDoesNotThrow(() -> FilterRegistry.applyNamedConfig(filter, "okf_xml"));
+    }
+
+    // ── Unknown / invalid config ids surface as errors ───────────────────────
+
+    @Test
+    void applyNamedConfig_unknownConfigId_throws() {
+        IFilter filter = newFilter(XML_FILTER);
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> FilterRegistry.applyNamedConfig(filter, "okf_xml-doesnotexist"));
+        assertTrue(ex.getMessage().contains("okf_xml-doesnotexist"),
+                "error message should name the bad config id, got: " + ex.getMessage());
+        // The message should also list the available configs to aid debugging.
+        assertTrue(ex.getMessage().contains("okf_xml-resx"),
+                "error message should list available configs, got: " + ex.getMessage());
+    }
+
+    @Test
+    void applyNamedConfig_nullConfigId_throws() {
+        IFilter filter = newFilter(XML_FILTER);
+        assertThrows(IllegalArgumentException.class,
+                () -> FilterRegistry.applyNamedConfig(filter, null));
+    }
+
+    @Test
+    void applyNamedConfig_emptyConfigId_throws() {
+        IFilter filter = newFilter(XML_FILTER);
+        assertThrows(IllegalArgumentException.class,
+                () -> FilterRegistry.applyNamedConfig(filter, ""));
+    }
+
+    @Test
+    void applyNamedConfig_nullFilter_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> FilterRegistry.applyNamedConfig(null, "okf_xml-resx"));
+    }
+}


### PR DESCRIPTION
Adds `ProcessHeader.config_id` (proto field 12) and `FilterRegistry.applyNamedConfig`: locate the `FilterConfiguration` matching the requested id among the filter's `getConfigurations()`, load its built-in parameters (`.fprm`/`.yml` ITS rules) via `IParameters.load`, and `setParameters()`. `BridgeServiceImpl` applies it in all three filter-open paths (read, two-pass write, legacy write) right after `createFilter` and before explicit `filter_params` (so params override the config). Unknown configId throws with the available ids listed.

Unblocks neokapi running the **DITA / DocBook / ResX** okf_xml/okf_xmlstream config-presets head-to-head against their native xml-config presets (neokapi #613, #611). Verified live in 1.48.0: `okf_xmlstream-dita`, `okf_xml-docbook`, `okf_xml-resx` are valid built-in config ids; the XML filter ships in `okapi-filter-its`.

`ApplyNamedConfigTest` (9 tests) covers resx/docbook/dita load, non-default effect, base-config no-op, and error cases. Full `bridge-core` suite **115/115 pass**; `make build V=1.48.0` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)