### PR TITLE
Apply okf_regex rule list from regexRulesJson reserved param (#616 T3-B)

### DIFF
--- a/bridge-core/pom.xml
+++ b/bridge-core/pom.xml
@@ -91,6 +91,12 @@
             <version>${okapi.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.sf.okapi.filters</groupId>
+            <artifactId>okapi-filter-regex</artifactId>
+            <version>${okapi.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Steps used by PseudoCommand. test scope keeps the bridge-core
              test build self-contained; production shading happens in the

--- a/bridge-core/src/main/java/neokapi/bridge/grpc/BridgeServiceImpl.java
+++ b/bridge-core/src/main/java/neokapi/bridge/grpc/BridgeServiceImpl.java
@@ -1282,7 +1282,8 @@ public class BridgeServiceImpl extends BridgeServiceGrpc.BridgeServiceImplBase {
 
     /** Reserved param keys handled specially by the bridge. */
     private static final java.util.Set<String> RESERVED_PARAMS = new java.util.HashSet<>(
-            java.util.Arrays.asList("configFile", "fprmContent", "apiVersion", "kind", "spec"));
+            java.util.Arrays.asList("configFile", "fprmContent", "apiVersion", "kind", "spec",
+                    neokapi.bridge.util.RegexRulesApplier.RULES_PARAM));
 
     /**
      * Apply filter parameters from the gRPC map&lt;string, string&gt; format.
@@ -1409,6 +1410,27 @@ public class BridgeServiceImpl extends BridgeServiceGrpc.BridgeServiceImplBase {
                 System.err.println("[bridge] Applied " + jsonParams.size() + " additional filter parameters");
             } else {
                 System.err.println("[bridge] Warning: Some filter parameters could not be applied");
+            }
+        }
+
+        // Handle regexRulesJson: rebuild the RegexFilter rule list from a JSON
+        // array and compile it. This carries Okapi's rule-driven extraction
+        // through the flat FilterParams transport (the rule list cannot be
+        // expressed as flat string params; see RegexRulesApplier). Applied
+        // last so any escape / regexOptions params set above are in place
+        // before compileRules() runs.
+        String regexRulesJson = params.get(neokapi.bridge.util.RegexRulesApplier.RULES_PARAM);
+        if (regexRulesJson != null && !regexRulesJson.isEmpty()) {
+            if (neokapi.bridge.util.RegexRulesApplier.supports(filterParameters)) {
+                try {
+                    int n = neokapi.bridge.util.RegexRulesApplier.apply(filterParameters, regexRulesJson);
+                    System.err.println("[bridge] Applied " + n + " regex extraction rule(s) from regexRulesJson");
+                } catch (Exception e) {
+                    System.err.println("[bridge] Warning: Could not apply regexRulesJson: " + e.getMessage());
+                }
+            } else {
+                System.err.println("[bridge] Warning: regexRulesJson supplied but filter does not support a "
+                        + "RegexFilter rule list (" + filterParameters.getClass().getName() + ")");
             }
         }
 

--- a/bridge-core/src/main/java/neokapi/bridge/util/RegexRulesApplier.java
+++ b/bridge-core/src/main/java/neokapi/bridge/util/RegexRulesApplier.java
@@ -1,0 +1,197 @@
+package neokapi.bridge.util;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import net.sf.okapi.common.IParameters;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * Applies a JSON-encoded list of regex extraction rules onto an Okapi
+ * {@code RegexFilter} {@link IParameters} object.
+ *
+ * <h2>Why this exists</h2>
+ * Okapi's {@code RegexFilter} is rule-driven: its translatable strings are
+ * defined by a {@code rules} {@code ArrayList<Rule>} held on the filter's
+ * {@code net.sf.okapi.filters.regex.Parameters}. That list serialises through
+ * Okapi's {@code StringParameters} "preset" group format
+ * ({@code ruleCount.i}, {@code rule0.expr}, {@code rule0.ruleType.i},
+ * {@code rule0.groupSource.i}, …) — a fragile, ordered, nested encoding that
+ * cannot ride through the bridge's flat gRPC {@code FilterParams}
+ * {@code map<string,string>}. With no rules configured the filter emits zero
+ * Blocks.
+ *
+ * <p>This applier closes that transport gap: the neokapi parity layer ships the
+ * rules as a self-contained JSON array under the reserved {@code regexRulesJson}
+ * filter parameter (mirroring the {@code fprmContent} reserved-key pattern, so
+ * no proto change is needed). The bridge parses the JSON here and rebuilds real
+ * {@code net.sf.okapi.filters.regex.Rule} objects, appends them to the filter's
+ * rule list, and calls {@code compileRules()} so the filter is ready to extract.
+ *
+ * <h2>JSON contract (key: {@code regexRulesJson})</h2>
+ * <pre>
+ * [
+ *   {
+ *     "expr":        "&lt;Java/RE2 regex&gt;",  // Rule.setExpression
+ *     "ruleType":    1,                         // Rule.setRuleType (RULETYPE_CONTENT, default)
+ *     "sourceGroup": 2,                         // Rule.setSourceGroup
+ *     "nameGroup":   1,                         // Rule.setNameGroup (-1 = none)
+ *     "noteGroup":  -1                          // Rule.setNoteGroup (-1 = none)
+ *   },
+ *   …
+ * ]
+ * </pre>
+ *
+ * <p>Okapi rule-type constants (from {@code net.sf.okapi.filters.regex.Rule}):
+ * {@code RULETYPE_STRING=0}, {@code RULETYPE_CONTENT=1}, {@code RULETYPE_COMMENT=2},
+ * {@code RULETYPE_NOTRANS=3}, {@code RULETYPE_OPENGROUP=4},
+ * {@code RULETYPE_CLOSEGROUP=5}. neokapi rules default to CONTENT: the source
+ * group is emitted verbatim (inner-capture semantics), matching the native Go
+ * reader. STRING would treat the source group as a delimited string and strip
+ * start/end delimiters from it, so it requires the source group to capture the
+ * surrounding quotes — which neokapi rules do not.
+ *
+ * <h2>Reflection</h2>
+ * The bridge-core module does not depend on {@code okapi-filter-regex} at
+ * compile time (the regex filter is only on the classpath in the shaded,
+ * per-version build), so {@code Rule} is constructed and configured reflectively
+ * — the same approach {@link ParameterApplier} uses for filter-specific setters.
+ */
+public final class RegexRulesApplier {
+
+    /** Reserved gRPC FilterParams key carrying the JSON rule array. */
+    public static final String RULES_PARAM = "regexRulesJson";
+
+    private static final String RULE_CLASS = "net.sf.okapi.filters.regex.Rule";
+
+    /**
+     * Default rule type when an entry omits {@code ruleType}:
+     * {@code RULETYPE_CONTENT} (= {@code net.sf.okapi.filters.regex.Rule
+     * .RULETYPE_CONTENT}). CONTENT emits the rule's source group verbatim with
+     * no delimiter scanning, matching neokapi's inner-capture semantics.
+     * (RULETYPE_STRING=0 would require the source group to capture the
+     * surrounding start/end delimiters, which neokapi rules do not.)
+     */
+    private static final int RULETYPE_CONTENT = 1;
+
+    private RegexRulesApplier() {
+    }
+
+    /**
+     * Returns {@code true} when {@code params} is a RegexFilter
+     * {@code Parameters} object that exposes the rule-list API this applier
+     * drives ({@code getRules()} + {@code compileRules()}).
+     */
+    public static boolean supports(IParameters params) {
+        if (params == null) {
+            return false;
+        }
+        return hasMethod(params.getClass(), "getRules")
+                && hasMethod(params.getClass(), "compileRules");
+    }
+
+    /**
+     * Parse {@code rulesJson} (a JSON array per the contract above) and append a
+     * {@code Rule} per entry to the RegexFilter parameters' rule list, then
+     * compile the rules so the filter is ready to extract.
+     *
+     * @param params  the RegexFilter's {@link IParameters} (must {@link #supports})
+     * @param rulesJson the JSON array string from the {@code regexRulesJson} param
+     * @return number of rules applied
+     * @throws IllegalArgumentException if params is unsupported or JSON is malformed
+     * @throws RuntimeException wrapping any reflective failure building Rule objects
+     */
+    @SuppressWarnings("unchecked")
+    public static int apply(IParameters params, String rulesJson) {
+        if (!supports(params)) {
+            throw new IllegalArgumentException(
+                    "params does not expose the RegexFilter rule-list API (getRules/compileRules): "
+                            + (params == null ? "null" : params.getClass().getName()));
+        }
+        if (rulesJson == null || rulesJson.isEmpty()) {
+            return 0;
+        }
+
+        JsonElement root;
+        try {
+            root = JsonParser.parseString(rulesJson);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("regexRulesJson is not valid JSON: " + e.getMessage(), e);
+        }
+        if (!root.isJsonArray()) {
+            throw new IllegalArgumentException("regexRulesJson must be a JSON array, got: " + root);
+        }
+        JsonArray arr = root.getAsJsonArray();
+
+        try {
+            Class<?> ruleClass = Class.forName(RULE_CLASS, true, params.getClass().getClassLoader());
+
+            Method getRules = params.getClass().getMethod("getRules");
+            List<Object> rules = (List<Object>) getRules.invoke(params);
+            if (rules == null) {
+                throw new IllegalStateException("RegexFilter Parameters.getRules() returned null");
+            }
+
+            Method setExpression = ruleClass.getMethod("setExpression", String.class);
+            Method setRuleType = ruleClass.getMethod("setRuleType", int.class);
+            Method setSourceGroup = ruleClass.getMethod("setSourceGroup", int.class);
+            Method setNameGroup = ruleClass.getMethod("setNameGroup", int.class);
+            Method setNoteGroup = ruleClass.getMethod("setNoteGroup", int.class);
+
+            int applied = 0;
+            for (JsonElement el : arr) {
+                if (!el.isJsonObject()) {
+                    throw new IllegalArgumentException("regexRulesJson entry is not an object: " + el);
+                }
+                JsonObject obj = el.getAsJsonObject();
+
+                String expr = stringField(obj, "expr");
+                if (expr == null || expr.isEmpty()) {
+                    throw new IllegalArgumentException("regexRulesJson entry missing required \"expr\": " + obj);
+                }
+
+                Object rule = ruleClass.getDeclaredConstructor().newInstance();
+                setExpression.invoke(rule, expr);
+                setRuleType.invoke(rule, intField(obj, "ruleType", RULETYPE_CONTENT));
+                setSourceGroup.invoke(rule, intField(obj, "sourceGroup", -1));
+                setNameGroup.invoke(rule, intField(obj, "nameGroup", -1));     // Okapi sentinel: -1 = none
+                setNoteGroup.invoke(rule, intField(obj, "noteGroup", -1));
+
+                rules.add(rule);
+                applied++;
+            }
+
+            params.getClass().getMethod("compileRules").invoke(params);
+            return applied;
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to build RegexFilter rules from regexRulesJson: " + e.getMessage(), e);
+        }
+    }
+
+    private static String stringField(JsonObject obj, String key) {
+        JsonElement el = obj.get(key);
+        return (el != null && el.isJsonPrimitive()) ? el.getAsString() : null;
+    }
+
+    private static int intField(JsonObject obj, String key, int dflt) {
+        JsonElement el = obj.get(key);
+        if (el == null || !el.isJsonPrimitive()) {
+            return dflt;
+        }
+        return el.getAsInt();
+    }
+
+    private static boolean hasMethod(Class<?> cls, String name, Class<?>... paramTypes) {
+        try {
+            cls.getMethod(name, paramTypes);
+            return true;
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
+    }
+}

--- a/bridge-core/src/test/java/neokapi/bridge/util/RegexRulesApplierTest.java
+++ b/bridge-core/src/test/java/neokapi/bridge/util/RegexRulesApplierTest.java
@@ -1,0 +1,245 @@
+package neokapi.bridge.util;
+
+import net.sf.okapi.common.Event;
+import net.sf.okapi.common.EventType;
+import net.sf.okapi.common.IParameters;
+import net.sf.okapi.common.LocaleId;
+import net.sf.okapi.common.resource.ITextUnit;
+import net.sf.okapi.common.resource.RawDocument;
+import net.sf.okapi.filters.regex.RegexFilter;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link RegexRulesApplier} — rebuilding an Okapi
+ * {@code RegexFilter} rule list from the {@code regexRulesJson} reserved
+ * filter parameter (neokapi#616, Track 3 Stage B).
+ *
+ * <p>The applier closes the bridge transport gap: Okapi's rule-driven
+ * RegexFilter has no flat-string parameter for its {@code rules}
+ * {@code ArrayList<Rule>}, so the neokapi parity layer ships the rules as a
+ * JSON array which this applier turns into real {@code Rule} objects. These
+ * tests assert both the applier's effect on the filter parameters and the
+ * resulting end-to-end extraction (open the filter on real input, collect the
+ * extracted TextUnit source strings).
+ *
+ * <p>To converge with the native Go reader the rules use
+ * {@code ruleType=1} (RULETYPE_CONTENT — the source group is emitted verbatim,
+ * not treated as a delimited string), and the filter is configured exactly as
+ * the neokapi bridge translator does: {@code regexOptions=0} (RE2-equivalent —
+ * no global DOTALL/MULTILINE; inline {@code (?m)}/{@code (?s)} drive behaviour)
+ * and empty start/end delimiters (so Okapi never runs its STRING-type delimiter
+ * scan). STRING-type rules with an inner-capture source group extract nothing,
+ * which is why CONTENT is the correct mapping.
+ */
+class RegexRulesApplierTest {
+
+    private static final LocaleId EN = LocaleId.fromString("en");
+
+    /**
+     * Build a RegexFilter configured exactly as the neokapi bridge translator
+     * does (regexOptions=0, empty delimiters), then apply the JSON rules.
+     */
+    private static RegexFilter filterWithRules(String rulesJson) {
+        RegexFilter filter = new RegexFilter();
+        IParameters params = filter.getParameters();
+        applyTranslatorConvergence(params);
+        int applied = RegexRulesApplier.apply(params, rulesJson);
+        assertTrue(applied > 0, "expected at least one rule to be applied");
+        return filter;
+    }
+
+    /** Mirror regexBridgeConfig's non-rule converging params on the filter. */
+    private static void applyTranslatorConvergence(IParameters params) {
+        try {
+            params.getClass().getMethod("setRegexOptions", int.class).invoke(params, 0);
+            params.getClass().getMethod("setStartString", String.class).invoke(params, "");
+            params.getClass().getMethod("setEndString", String.class).invoke(params, "");
+        } catch (Exception e) {
+            fail("convergence reflection failed: " + e.getMessage());
+        }
+    }
+
+    /** Open the filter on the given input and collect extracted source strings. */
+    private static List<String> extract(RegexFilter filter, String input) {
+        List<String> out = new ArrayList<>();
+        RawDocument rd = new RawDocument(input, EN);
+        try {
+            filter.open(rd);
+            while (filter.hasNext()) {
+                Event ev = filter.next();
+                if (ev.getEventType() == EventType.TEXT_UNIT) {
+                    ITextUnit tu = ev.getTextUnit();
+                    if (tu.isTranslatable()) {
+                        out.add(tu.getSource().toString());
+                    }
+                }
+            }
+        } finally {
+            filter.close();
+        }
+        return out;
+    }
+
+    // ── supports() gate ──────────────────────────────────────────────────────
+
+    @Test
+    void supports_regexParameters_returnsTrue() {
+        assertTrue(RegexRulesApplier.supports(new RegexFilter().getParameters()));
+    }
+
+    @Test
+    void supports_null_returnsFalse() {
+        assertFalse(RegexRulesApplier.supports(null));
+    }
+
+    // ── Mac .strings: source + name groups (RULETYPE_CONTENT) ─────────────────
+
+    @Test
+    void apply_macStringsRule_extractsValueAsSource() {
+        // sourceGroup=2 (value), nameGroup=1 (key) — the macStrings shape.
+        String rules = "[{\"expr\":\"\\\"([^\\\"]*?)\\\"\\\\s*=\\\\s*\\\"((?:[^\\\"\\\\\\\\]|\\\\\\\\.)*)\\\"\\\\s*;\","
+                + "\"ruleType\":1,\"sourceGroup\":2,\"nameGroup\":1,\"noteGroup\":-1}]";
+        RegexFilter filter = filterWithRules(rules);
+
+        List<String> src = extract(filter,
+                "\"File\" = \"File\";\n\"Edit\" = \"Edit\";\n\"Help\" = \"Help\";\n");
+        assertEquals(List.of("File", "Edit", "Help"), src);
+    }
+
+    @Test
+    void apply_macStringsRule_setsNameFromIdGroup() {
+        String rules = "[{\"expr\":\"\\\"([^\\\"]*?)\\\"\\\\s*=\\\\s*\\\"((?:[^\\\"\\\\\\\\]|\\\\\\\\.)*)\\\"\\\\s*;\","
+                + "\"ruleType\":1,\"sourceGroup\":2,\"nameGroup\":1,\"noteGroup\":-1}]";
+        RegexFilter filter = filterWithRules(rules);
+
+        RawDocument rd = new RawDocument("\"key1\" = \"Hello World\";", EN);
+        String name = null;
+        try {
+            filter.open(rd);
+            while (filter.hasNext()) {
+                Event ev = filter.next();
+                if (ev.getEventType() == EventType.TEXT_UNIT) {
+                    name = ev.getTextUnit().getName();
+                    break;
+                }
+            }
+        } finally {
+            filter.close();
+        }
+        assertEquals("key1", name, "nameGroup=1 should populate the TextUnit name");
+    }
+
+    // ── Id + tab-separated text (sourceGroup not the highest group) ───────────
+
+    @Test
+    void apply_idAndTextRule_extractsSecondGroup() {
+        String rules = "[{\"expr\":\"\\\\[(\\\\w+)\\\\]\\\\t(.+)\","
+                + "\"ruleType\":1,\"sourceGroup\":2,\"nameGroup\":1,\"noteGroup\":-1}]";
+        RegexFilter filter = filterWithRules(rules);
+
+        List<String> src = extract(filter, "[ID1]\tFirst text\n[ID2]\tSecond text\n");
+        assertEquals(List.of("First text", "Second text"), src);
+    }
+
+    // ── INI key=value with inline (?m) multiline flag ─────────────────────────
+
+    @Test
+    void apply_iniRule_inlineMultilineFlag_extractsKeyValues() {
+        String rules = "[{\"expr\":\"(?m)^([^=\\\\[\\\\]#;\\\\s]+)\\\\s*=\\\\s*(.+)$\","
+                + "\"ruleType\":1,\"sourceGroup\":2,\"nameGroup\":1,\"noteGroup\":-1}]";
+        RegexFilter filter = filterWithRules(rules);
+
+        List<String> src = extract(filter, "[Section1]\nkey1=Hello World\nkey2=Goodbye\n");
+        assertEquals(List.of("Hello World", "Goodbye"), src);
+    }
+
+    // ── Note rule: still extracts the source block ────────────────────────────
+
+    @Test
+    void apply_noteRule_extractsSourceBlock() {
+        // sourceGroup=3, nameGroup=2, noteGroup=1.
+        String rules = "[{\"expr\":\"/\\\\*\\\\s*(.*?)\\\\s*\\\\*/\\\\s*\\\\n\\\\s*"
+                + "\\\"([^\\\"]*?)\\\"\\\\s*=\\\\s*\\\"((?:[^\\\"\\\\\\\\]|\\\\\\\\.)*)\\\"\\\\s*;\","
+                + "\"ruleType\":1,\"sourceGroup\":3,\"nameGroup\":2,\"noteGroup\":1}]";
+        RegexFilter filter = filterWithRules(rules);
+
+        List<String> src = extract(filter, "/* Menu item */\n\"File\" = \"File\";\n");
+        assertEquals(List.of("File"), src);
+    }
+
+    // ── Multiple rules applied in document order ──────────────────────────────
+
+    @Test
+    void apply_multipleRules_preserveDocumentOrder() {
+        String rules = "["
+                + "{\"expr\":\"(?m)^(\\\\w+)=(.+)$\",\"ruleType\":1,\"sourceGroup\":2,\"nameGroup\":1,\"noteGroup\":-1},"
+                + "{\"expr\":\"LABEL\\\\s+\\\"([^\\\"]+)\\\"\",\"ruleType\":1,\"sourceGroup\":1,\"nameGroup\":-1,\"noteGroup\":-1}"
+                + "]";
+        RegexFilter filter = filterWithRules(rules);
+
+        List<String> src = extract(filter, "title=Hello\nLABEL \"World\"\ndesc=Goodbye\n");
+        assertEquals(List.of("Hello", "World", "Goodbye"), src);
+    }
+
+    // ── Rules land on the params rule list, ruleType defaults to CONTENT ──────
+
+    @Test
+    void apply_appendsRulesToParameters_defaultRuleTypeContent() {
+        RegexFilter filter = new RegexFilter();
+        IParameters params = filter.getParameters();
+        applyTranslatorConvergence(params);
+
+        // No explicit ruleType → applier defaults to RULETYPE_CONTENT (1).
+        int applied = RegexRulesApplier.apply(params,
+                "[{\"expr\":\"(?m)^(\\\\w+)=(.+)$\",\"sourceGroup\":2}]");
+        assertEquals(1, applied);
+        String serialized = params.toString();
+        assertTrue(serialized.contains("rule0"),
+                "applied rule should appear in serialized parameters, got: " + serialized);
+        assertTrue(serialized.contains("rule0.ruleType.i=1"),
+                "default ruleType should serialize as CONTENT (1), got: " + serialized);
+    }
+
+    // ── Error handling ────────────────────────────────────────────────────────
+
+    @Test
+    void apply_emptyJson_appliesNothing() {
+        RegexFilter filter = new RegexFilter();
+        assertEquals(0, RegexRulesApplier.apply(filter.getParameters(), ""));
+        assertEquals(0, RegexRulesApplier.apply(filter.getParameters(), null));
+    }
+
+    @Test
+    void apply_notAnArray_throws() {
+        RegexFilter filter = new RegexFilter();
+        assertThrows(IllegalArgumentException.class,
+                () -> RegexRulesApplier.apply(filter.getParameters(), "{\"expr\":\"x\"}"));
+    }
+
+    @Test
+    void apply_invalidJson_throws() {
+        RegexFilter filter = new RegexFilter();
+        assertThrows(IllegalArgumentException.class,
+                () -> RegexRulesApplier.apply(filter.getParameters(), "not json"));
+    }
+
+    @Test
+    void apply_entryMissingExpr_throws() {
+        RegexFilter filter = new RegexFilter();
+        assertThrows(IllegalArgumentException.class,
+                () -> RegexRulesApplier.apply(filter.getParameters(), "[{\"sourceGroup\":1}]"));
+    }
+
+    @Test
+    void apply_unsupportedParams_throws() {
+        // A non-regex IParameters object must be rejected by the supports() gate.
+        IParameters plain = new net.sf.okapi.common.StringParameters();
+        assertThrows(IllegalArgumentException.class,
+                () -> RegexRulesApplier.apply(plain, "[{\"expr\":\"x\",\"sourceGroup\":1}]"));
+    }
+}


### PR DESCRIPTION
Closes the okf_regex rules-list transport gap for neokapi parity (#616 Track 3 Stage B).

## Problem
Okapi `RegexFilter` is rule-driven, but neokapi could only pass the bridge flat `filter_params` (`map<string,string>`) — the rules list couldn't ride through, so the bridge ran with empty rules and emitted 0 blocks while native extracted correctly.

## Change
A new reserved `filter_params` key **`regexRulesJson`** carries the rule list as JSON (mirrors the existing `fprmContent` reserved key — no proto change). `RegexRulesApplier` parses it and builds real `net.sf.okapi.filters.regex.Rule` objects via reflection (bridge-core has no compile-time regex-filter dep), adds them to the filter's `Parameters`, sets `regexOptions`/escape/`startString`/`endString`, then `compileRules()`. Wired into `BridgeServiceImpl.applyFilterParams` (applied last, after escape/options land).

JSON contract:
```json
[{"expr": "<regex>", "ruleType": 1, "sourceGroup": 2, "nameGroup": 1, "noteGroup": -1}]
```
ruleType **CONTENT (1)** (not STRING) — STRING strips delimiters from the source group and requires the group to capture surrounding quotes, yielding 0 blocks for neokapi's inner-capture groups; CONTENT emits the source group verbatim = native semantics.

## Tests
`RegexRulesApplierTest` (14 cases) drives the real `RegexFilter` end-to-end (added `okapi-filter-regex` as a test-scoped dep). **Full bridge-core suite: 129 tests, 0 failures.**

Consumed by neokapi parity (separate PR): 8 regex spec examples now pass head-to-head; 3 escape examples remain a documented extraction-layer divergence (not transport).