### PR TITLE
fix(grpc): reflective Segment.originalId alignment for old Okapi (unblocks release matrix)

### DIFF
--- a/bridge-core/src/main/java/neokapi/bridge/grpc/StreamingTranslationApplier.java
+++ b/bridge-core/src/main/java/neokapi/bridge/grpc/StreamingTranslationApplier.java
@@ -12,6 +12,7 @@ import net.sf.okapi.common.resource.TextContainer;
 import net.sf.okapi.common.resource.TextFragment;
 import net.sf.okapi.common.resource.TextPart;
 
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -111,7 +112,7 @@ public class StreamingTranslationApplier {
             Segment tgtSeg = targetContainer.getFirstSegment();
             if (srcSeg != null && tgtSeg != null) {
                 tgtSeg.id = srcSeg.id;
-                tgtSeg.setOriginalId(srcSeg.getOriginalId());
+                copySegmentOriginalId(srcSeg, tgtSeg);
             }
         } else {
             // Multi-segment (or single DTO for multi-segment source):
@@ -226,6 +227,24 @@ public class StreamingTranslationApplier {
                 return entry.segments();
             }
             lookahead.put(entry.blockId(), entry.segments());
+        }
+    }
+
+    // copySegmentOriginalId aligns the target segment's originalId with the
+    // source's, used so writers (XLIFF2, etc.) can match source↔target pairs.
+    // Segment-level originalId was added to Okapi after the older releases the
+    // bridge still supports (≤1.41 have no Segment.getOriginalId/setOriginalId),
+    // so reflect over it and no-op when absent — those versions have no segment
+    // originalId to preserve. Newer versions behave exactly as a direct call.
+    private static void copySegmentOriginalId(Segment src, Segment tgt) {
+        try {
+            Method get = Segment.class.getMethod("getOriginalId");
+            Method set = Segment.class.getMethod("setOriginalId", String.class);
+            set.invoke(tgt, get.invoke(src));
+        } catch (NoSuchMethodException e) {
+            // Older Okapi: Segment has no originalId — nothing to align.
+        } catch (ReflectiveOperationException e) {
+            // Defensive: never fail translation application over ID alignment.
         }
     }
 }


### PR DESCRIPTION
The release build matrix has been broken for older Okapi versions (0.38/1.39/1.40/1.41) since the segment-ID alignment work landed (`1a94567`, `bd61b4e`) — surfaced when cutting v2.53.0 (build failed; no release published).

`StreamingTranslationApplier.java:114` calls `Segment.getOriginalId()`/`setOriginalId()`, which don't exist in Okapi ≤1.41 → `cannot find symbol`. (Unrelated to the regex handler from #13, which builds fine on 1.48.)

## Fix
Guard the segment-originalId alignment with a small reflective helper (matching the bridge's existing reflection-for-compat pattern): no-op on versions that lack `Segment.originalId` (they have no segment originalId to preserve), behavior-identical on newer versions.

## Verified locally
- `make build V=0.38` → BUILD SUCCESS
- `make build V=1.41.0` → BUILD SUCCESS (was the failing version)
- `make test V=1.48.0` → 129 tests, 0 failures (`StreamingTranslationApplierTest` passes — no regression)

Unblocks the v2.x release matrix.