### PR TITLE
feat(dtd): expose configurable code-finder rules (okf_dtd)

### DIFF
--- a/overrides/filters/okf_dtd.overrides.json
+++ b/overrides/filters/okf_dtd.overrides.json
@@ -10,6 +10,7 @@
     },
     "codeFinderRules": {
       "title": "Code Finder Rules",
+      "widget": "codeFinderRules",
       "description": "Regular expressions in #v1 format defining patterns to treat as inline codes."
     }
   }

--- a/schemas/filters/base/okf_dtd.v4.schema.json
+++ b/schemas/filters/base/okf_dtd.v4.schema.json
@@ -34,6 +34,38 @@
       "type": "string",
       "description": "Simplifier rules for code type normalization",
       "x-widget": "simplifierRulesEditor"
+    },
+    "codeFinderRules": {
+      "type": "object",
+      "description": "Inline code detection configuration",
+      "properties": {
+        "rules": {
+          "type": "array",
+          "description": "List of regex patterns to detect inline codes",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pattern": {
+                "type": "string",
+                "description": "Regex pattern for inline code detection"
+              }
+            },
+            "required": [
+              "pattern"
+            ]
+          }
+        },
+        "sample": {
+          "type": "string",
+          "description": "Sample text to test patterns against"
+        },
+        "useAllRulesWhenTesting": {
+          "type": "boolean",
+          "default": true,
+          "description": "Test all rules together or individually"
+        }
+      },
+      "x-okapiFormat": "inlineCodeFinder"
     }
   },
   "additionalProperties": false

--- a/schemas/filters/composite/okf_dtd.v4.schema.json
+++ b/schemas/filters/composite/okf_dtd.v4.schema.json
@@ -39,6 +39,42 @@
       "description": "Rules for simplifying inline code representation",
       "x-widget": "simplifierRulesEditor",
       "title": "Simplifier Rules"
+    },
+    "codeFinderRules": {
+      "type": "object",
+      "description": "Regular expressions in #v1 format defining patterns to treat as inline codes.",
+      "properties": {
+        "rules": {
+          "type": "array",
+          "description": "List of regex patterns to detect inline codes",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pattern": {
+                "type": "string",
+                "description": "Regex pattern for inline code detection"
+              }
+            },
+            "required": [
+              "pattern"
+            ]
+          }
+        },
+        "sample": {
+          "type": "string",
+          "description": "Sample text to test patterns against"
+        },
+        "useAllRulesWhenTesting": {
+          "type": "boolean",
+          "default": true,
+          "description": "Test all rules together or individually"
+        }
+      },
+      "x-okapiFormat": "inlineCodeFinder",
+      "title": "Code Finder Rules",
+      "x-editor": {
+        "widget": "codeFinderRules"
+      }
     }
   },
   "additionalProperties": false,
@@ -46,6 +82,6 @@
   "x-apiVersion": "v4",
   "x-baseVersion": 4,
   "x-introducedInOkapi": "1.47.0",
-  "x-baseHash": "f11cfe564c78",
-  "x-compositeHash": "02a5dda78ec2"
+  "x-baseHash": "cc1b0df4098d",
+  "x-compositeHash": "2537c3da9a02"
 }

--- a/schemas/versions.json
+++ b/schemas/versions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://neokapi.dev/schemas/schema-versions.json",
-  "generatedAt": "2026-04-02T21:44:33Z",
+  "generatedAt": "2026-05-23T12:00:08Z",
   "filters": {
     "okf_archive": {
       "versions": [
@@ -805,7 +805,7 @@
           "version": 1,
           "baseVersion": 1,
           "baseHash": "82bec33a66fe",
-          "overrideHash": "826a9b465c4f",
+          "overrideHash": "2a8bac37a536",
           "compositeHash": "e593cc6cf822",
           "kind": "OkfDtdFilterConfig",
           "apiVersion": "v1",
@@ -825,7 +825,7 @@
           "version": 2,
           "baseVersion": 2,
           "baseHash": "f11cfe564c78",
-          "overrideHash": "826a9b465c4f",
+          "overrideHash": "2a8bac37a536",
           "compositeHash": "02a5dda78ec2",
           "kind": "OkfDtdFilterConfig",
           "apiVersion": "v2",
@@ -839,7 +839,7 @@
           "version": 3,
           "baseVersion": 3,
           "baseHash": "46daa29a2f55",
-          "overrideHash": "826a9b465c4f",
+          "overrideHash": "2a8bac37a536",
           "compositeHash": "e16846cda8c9",
           "kind": "OkfDtdFilterConfig",
           "apiVersion": "v3",
@@ -851,9 +851,9 @@
         {
           "version": 4,
           "baseVersion": 4,
-          "baseHash": "f11cfe564c78",
-          "overrideHash": "826a9b465c4f",
-          "compositeHash": "02a5dda78ec2",
+          "baseHash": "cc1b0df4098d",
+          "overrideHash": "2a8bac37a536",
+          "compositeHash": "2537c3da9a02",
           "kind": "OkfDtdFilterConfig",
           "apiVersion": "v4",
           "introducedInOkapi": "1.47.0",

--- a/tools/schema-generator/src/main/java/neokapi/bridge/tools/ParameterIntrospector.java
+++ b/tools/schema-generator/src/main/java/neokapi/bridge/tools/ParameterIntrospector.java
@@ -702,6 +702,17 @@ public class ParameterIntrospector {
                     if (existing != null) {
                         existing.okapiFormat = "inlineCodeFinder";
                         existing.type = "object";  // Will be transformed to clean object format
+                    } else {
+                        // Some StringParameters filters (e.g. DTD) hold an
+                        // InlineCodeFinder and serialize it via
+                        // setGroup("codeFinderRules", ...) / getGroup(...) but
+                        // declare no String constant for it, so the constant
+                        // scan above never surfaces the parameter. Create it
+                        // here so the rich code-finder editor is exposed, on a
+                        // par with filters that do declare the constant.
+                        ParamInfo created = new ParamInfo("codeFinderRules", "object");
+                        created.okapiFormat = "inlineCodeFinder";
+                        result.put("codeFinderRules", created);
                     }
                 }
             } catch (Exception e) {


### PR DESCRIPTION
The Okapi DTD filter round-trips a custom `InlineCodeFinder` via `setGroup`/`getGroup("codeFinderRules", ...)`, but the schema generator never surfaced the parameter because DTD's `StringParameters` declares no String constant for it. The reference UI therefore showed a "Use Code Finder" toggle with **no** rules editor, unlike `okf_html` and the other inline-code filters.

## Changes
- **`ParameterIntrospector.introspectComplexFields`** — create the `codeFinderRules` parameter (`okapiFormat=inlineCodeFinder`) when a `StringParameters` filter has an `InlineCodeFinder` field but no constant surfaced it. Durable fix for any such filter; `SchemaTransformer` renders the standard `{rules:[{pattern}], sample, useAllRulesWhenTesting}` shape.
- **`okf_dtd` base schema** — add the `codeFinderRules` object so the override's widget hint has a property to attach to (the merge applies hints to existing properties only).
- **`okf_dtd` override** — declare `"widget": "codeFinderRules"` explicitly; the `$include` inlineCodes fragment is shallow-overwritten by the override's own field during resolution.
- Regenerated composite + versions.

## Verification
`make verify-schemas` passes. `dist/plugin/formats/okf_dtd/schema.json` now exposes `ui:widget: codeFinderRules` + `x-okapi-format: inlineCodeFinder`, matching `okf_html`. Verified end-to-end on the neokapi docs Format Reference: the DTD Filter modal renders the rich Code Finder Rules editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)