### PR TITLE
fix(proto): compile the split neokapi proto pair (content.proto + bridge)

### DIFF
--- a/bridge-core/src/main/proto/core/proto/content/v1/content.proto
+++ b/bridge-core/src/main/proto/core/proto/content/v1/content.proto
@@ -1,0 +1,347 @@
+// content.proto — the canonical wire schema for the neokapi content model
+// (Part / Block / Run / Overlay / Target / Skeleton — see AD-002 and AD-034).
+//
+// These messages were promoted VERBATIM from
+// core/plugin/proto/v2/neokapi_bridge.proto — same message shapes, same field
+// names, same field numbers — so the wire encoding of every field is
+// unchanged. Only the proto package (and thus the fully-qualified type names,
+// which matter for google.protobuf.Any packing and descriptor reflection,
+// neither of which the repo uses on these messages) changed.
+//
+// Compatibility policy:
+//   - Field numbers are FROZEN. Never renumber or repurpose a field.
+//   - Never rename fields (protojson and cross-language peers depend on names).
+//   - New fields append with fresh numbers; removed fields are reserved.
+//   - The Java okapi-bridge compiles this file alongside the bridge service
+//     proto; java_package stays "neokapi.bridge.proto" so the generated Java
+//     class names (and thus the Java bridge sources) are unchanged.
+//
+// Every other serialization of Blocks/Runs in the repo is either an import of
+// this schema or an explicitly-labeled lossy projection (BlockIndex,
+// ContentTree, structrec.Record, the bowrain editor proto). A guard test
+// (core/proto/content/guard_test.go) rejects new Block/Run message
+// definitions outside this file.
+
+syntax = "proto3";
+
+package neokapi.content.v1;
+
+option go_package = "github.com/neokapi/neokapi/core/proto/content/v1;contentv1";
+option java_package = "neokapi.bridge.proto";
+option java_multiple_files = true;
+
+// ────────────────────────────────────────────────────────────────────────────
+// Annotations
+// ────────────────────────────────────────────────────────────────────────────
+
+// AnnotationEntry is a typed annotation with a JSON-encoded payload.
+message AnnotationEntry {
+  string type = 1;    // "note", "alt-translation", "its-lqi", "generic", etc.
+  bytes data = 2;     // JSON-encoded type-specific payload
+}
+
+// RunRangeMessage is a run-anchored byte/run span (the position of a
+// overlay span).
+message RunRangeMessage {
+  int32 start_run = 1;
+  int32 start_offset = 2;
+  int32 end_run = 3;
+  int32 end_offset = 4;
+}
+
+// VariantMessage identifies a target variant (locale + optional tone/channel).
+// Its absence on an OverlayMessage means the overlay is source-side.
+message VariantMessage {
+  string locale = 1;
+  string tone = 2;
+  string channel = 3;
+}
+
+// SpanMessage is one occurrence within an overlay: a run-anchored
+// range, optional string props, and the typed payload (carried as an
+// AnnotationEntry so unknown payload types degrade to a generic map, exactly
+// like block-scoped annotations).
+message SpanMessage {
+  string id = 1;
+  RunRangeMessage range = 2;
+  map<string, string> props = 3;
+  AnnotationEntry value = 4;
+}
+
+// OverlayMessage is one stand-off overlay on a block: a typed, optionally
+// variant-scoped, layered set of spans. This carries the full overlay vocabulary
+// across the wire (term, entity, qa, alignment, and any plugin-defined
+// type), so an overlay type a peer doesn't recognise round-trips by type name and
+// JSON rather than being dropped. Segmentation overlays are NOT carried here —
+// they are reconstructed from the source/target SegmentMessage boundaries.
+message OverlayMessage {
+  string type = 1;             // overlay type ("term", "entity", "qa", …)
+  VariantMessage variant = 2;  // absent = source side
+  string layer = 3;            // "" = primary
+  repeated SpanMessage spans = 4;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Inline Markup (RFC 0001 Run model)
+// ────────────────────────────────────────────────────────────────────────────
+
+// RunConstraints control whether an inline-code run may be dropped,
+// duplicated, or reordered by a translation.
+message RunConstraints {
+  bool deletable = 1;
+  bool cloneable = 2;
+  bool reorderable = 3;
+}
+
+// TextRunMessage is a plain text chunk.
+message TextRunMessage {
+  string text = 1;
+}
+
+// PlaceholderRunMessage is a self-closing inline code (variable,
+// conditional JSX expression, line break, icon, etc.).
+message PlaceholderRunMessage {
+  string id = 1;
+  string type = 2;      // Vocabulary key, e.g. "jsx:var", "jsx:node", "html:br".
+  string sub_type = 3;  // Fine-grained discriminator.
+  string data = 4;      // Original source slice, preserved verbatim.
+  string equiv = 5;     // Stable human-friendly identifier (variable name, tag name).
+  string disp = 6;      // Display label for chips.
+  RunConstraints constraints = 7;
+}
+
+// PcOpenRunMessage is the opening half of a paired inline code.
+message PcOpenRunMessage {
+  string id = 1;
+  string type = 2;
+  string sub_type = 3;
+  string data = 4;      // Raw opening source ("<span class=\"muted\">").
+  string equiv = 5;
+  string disp = 6;
+  RunConstraints constraints = 7;
+}
+
+// PcCloseRunMessage is the closing half of a paired inline code.
+// Shares id with its PcOpen inside the same runs scope.
+message PcCloseRunMessage {
+  string id = 1;
+  string type = 2;
+  string sub_type = 3;
+  string data = 4;      // Raw closing source ("</span>").
+  string equiv = 5;
+}
+
+// SubRunMessage is a reference to a subblock (sub-filter output).
+message SubRunMessage {
+  string id = 1;
+  string ref = 2;
+  string equiv = 3;
+}
+
+// PluralRunMessage is a structured plural construct. Keys of `forms`
+// are ICU plural forms: "zero", "one", "two", "few", "many", "other".
+message PluralRunMessage {
+  string pivot = 1;
+  map<string, RunList> forms = 2;
+}
+
+// SelectRunMessage is a structured select construct, symmetric to
+// PluralRunMessage but keyed by arbitrary case values.
+message SelectRunMessage {
+  string pivot = 1;
+  map<string, RunList> cases = 2;
+}
+
+// RunList is a repeated-field holder used by map values in
+// PluralRunMessage and SelectRunMessage (proto3 maps cannot have
+// repeated-message values directly).
+message RunList {
+  repeated RunMessage runs = 1;
+}
+
+// RunMessage is the discriminated-union inline-content primitive.
+// Exactly one of the oneof fields is present per Run.
+message RunMessage {
+  oneof kind {
+    TextRunMessage text = 1;
+    PlaceholderRunMessage ph = 2;
+    PcOpenRunMessage pc_open = 3;
+    PcCloseRunMessage pc_close = 4;
+    SubRunMessage sub = 5;
+    PluralRunMessage plural = 6;
+    SelectRunMessage select = 7;
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Segments & Targets
+// ────────────────────────────────────────────────────────────────────────────
+
+// SegmentMessage represents a single segment within a Block.
+message SegmentMessage {
+  string id = 1;
+  repeated RunMessage runs = 2;
+  map<string, string> properties = 3;
+}
+
+// TargetEntry maps a locale to its target segments.
+message TargetEntry {
+  string locale = 1;
+  repeated SegmentMessage segments = 2;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Lightweight Block (for gRPC transfer — no skeleton, no display hints)
+// ────────────────────────────────────────────────────────────────────────────
+
+// ContentBlock is a lightweight representation of a translatable block
+// designed for efficient gRPC transfer. It carries only the fields that
+// Go-side tools need for content processing — source/target text with
+// inline markup, properties, and identity. The heavy fields (skeleton,
+// display hints, is_referent) stay on the producing side.
+//
+// Size comparison for a typical XLSX cell:
+//   BlockMessage:   ~500 bytes (skeleton dominates)
+//   ContentBlock:   ~50 bytes  (just id + text)
+message ContentBlock {
+  string id = 1;
+  string name = 2;
+  string type = 3;
+  string mime_type = 4;
+  bool translatable = 5;
+  repeated SegmentMessage source = 6;
+  repeated TargetEntry targets = 7;
+  map<string, string> properties = 8;
+  bool preserve_whitespace = 9;
+  map<string, AnnotationEntry> annotations = 10;
+  DisplayHintMessage display_hint = 11;
+  // Stand-off overlays (see BlockMessage.overlays).
+  repeated OverlayMessage overlays = 12;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Skeleton
+// ────────────────────────────────────────────────────────────────────────────
+
+// SkeletonMessage preserves non-translatable structure for reconstruction.
+message SkeletonMessage {
+  int32 strategy = 1;                   // 0=FragmentBased, 1=Reparse
+  repeated SkeletonPartMessage parts = 2;
+  string source_uri = 3;
+}
+
+// SkeletonPartMessage is either a text fragment or a resource reference.
+message SkeletonPartMessage {
+  string text = 1;         // Literal text (set for text parts)
+  string resource_id = 2;  // Resource ID (set for reference parts)
+  string property = 3;     // Property to reference (e.g., "target", "source")
+  string locale = 4;       // Target locale for locale-specific references
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Display Hints
+// ────────────────────────────────────────────────────────────────────────────
+
+// DisplayHintMessage provides rendering guidance for UI tools.
+message DisplayHintMessage {
+  int32 max_length = 1;     // Maximum character count (0 = unlimited)
+  string content_type = 2;  // Content type hint (e.g., "heading", "button")
+  string context = 3;       // Description of where this block appears
+  string preview = 4;       // Short preview of surrounding context
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Content Units
+// ────────────────────────────────────────────────────────────────────────────
+
+// BlockMessage represents a translatable content unit.
+message BlockMessage {
+  string id = 1;
+  string name = 2;
+  string type = 3;
+  string mime_type = 4;
+  bool translatable = 5;
+  repeated SegmentMessage source = 6;
+  repeated TargetEntry targets = 7;
+  map<string, string> properties = 8;
+  map<string, AnnotationEntry> annotations = 9;
+  DisplayHintMessage display_hint = 10;
+  SkeletonMessage skeleton = 11;
+  bool preserve_whitespace = 12;
+  bool is_referent = 13;
+  // Stand-off overlays (term, entity, qa, alignment, plugin types).
+  // Segmentation is reconstructed from source/targets, so it is not repeated here.
+  repeated OverlayMessage overlays = 14;
+}
+
+// LayerMessage represents a structural layer.
+message LayerMessage {
+  string id = 1;
+  string name = 2;
+  string format = 3;
+  string locale = 4;
+  string encoding = 5;
+  string mime_type = 6;
+  string line_break = 7;
+  bool is_multilingual = 8;
+  string parent_id = 9;
+  map<string, string> properties = 10;
+  bool has_bom = 11;
+}
+
+// DataMessage represents non-translatable document structure.
+message DataMessage {
+  string id = 1;
+  string name = 2;
+  map<string, string> properties = 3;
+  SkeletonMessage skeleton = 4;
+  bool is_referent = 5;
+}
+
+// GroupStartMessage signals the beginning of a structural group.
+message GroupStartMessage {
+  string id = 1;
+  string name = 2;
+  string type = 3;
+  map<string, string> properties = 4;
+}
+
+// GroupEndMessage signals the end of a structural group.
+message GroupEndMessage {
+  string id = 1;
+}
+
+// MediaMessage holds binary or media content.
+message MediaMessage {
+  string id = 1;
+  string mime_type = 2;
+  bytes data = 3;
+  string uri = 4;
+  string alt_text = 5;
+  map<string, string> properties = 6;
+}
+
+// PartMessage is the fundamental unit flowing through a stream.
+message PartMessage {
+  int32 part_type = 1;
+  // Only one of these is set, based on part_type.
+  BlockMessage block = 2;
+  LayerMessage layer = 3;
+  DataMessage data = 4;
+  GroupStartMessage group_start = 5;
+  GroupEndMessage group_end = 6;
+  MediaMessage media = 7;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Content references
+// ────────────────────────────────────────────────────────────────────────────
+
+// ContentRef allows passing content as a file path instead of inline bytes.
+message ContentRef {
+  oneof location {
+    bytes  inline = 1;  // Inline bytes
+    string path   = 2;  // Local filesystem path
+    string uri    = 3;  // Remote/local URI (file://, s3://, gs://)
+  }
+}

--- a/bridge-core/src/main/proto/neokapi/bridge/v2/neokapi_bridge.proto
+++ b/bridge-core/src/main/proto/neokapi/bridge/v2/neokapi_bridge.proto
@@ -1,6 +1,22 @@
+// neokapi_bridge.proto — the plugin/bridge gRPC service surface.
+//
+// This file holds only the BridgeService and its request/response envelope
+// messages. The content-model messages (PartMessage, BlockMessage, the
+// RunMessage discriminated union, overlays, skeleton, …) live in the
+// canonical wire schema at core/proto/content/v1/content.proto (imported
+// below). They were moved there verbatim — same field names and numbers —
+// so the wire encoding is unchanged; see that file for the compatibility
+// policy (field numbers frozen, no renames).
+//
+// The Java okapi-bridge compiles both files; content.proto keeps
+// java_package "neokapi.bridge.proto" so the generated Java classes are
+// unchanged.
+
 syntax = "proto3";
 
 package neokapi.bridge.v2;
+
+import "core/proto/content/v1/content.proto";
 
 option go_package = "github.com/neokapi/neokapi/core/plugin/proto/v2;bridgev2";
 option java_package = "neokapi.bridge.proto";
@@ -33,284 +49,20 @@ service BridgeService {
   // feeds each part through the step and returns processed parts.
   rpc ProcessStep(stream StepRequest) returns (stream StepResponse);
 
+  // Segment runs a text segmenter and returns interior sentence/chunk
+  // boundaries. It backs plugin-provided segmentation engines declared via
+  // capabilities.segmenters: the host flattens a block's runs to code-masked
+  // text and asks the daemon for the boundaries, then projects them back to
+  // run-anchored spans. Unary — one text in, boundary offsets out.
+  rpc Segment(SegmentRequest) returns (SegmentResponse);
+
   // Shutdown gracefully shuts down the bridge server.
   rpc Shutdown(ShutdownRequest) returns (ShutdownResponse);
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// Annotations
-// ────────────────────────────────────────────────────────────────────────────
-
-// AnnotationEntry is a typed annotation with a JSON-encoded payload.
-message AnnotationEntry {
-  string type = 1;    // "note", "alt-translation", "its-lqi", "generic", etc.
-  bytes data = 2;     // JSON-encoded type-specific payload
-}
-
-// ────────────────────────────────────────────────────────────────────────────
-// Inline Markup (RFC 0001 Run model)
-// ────────────────────────────────────────────────────────────────────────────
-
-// RunConstraints control whether an inline-code run may be dropped,
-// duplicated, or reordered by a translation.
-message RunConstraints {
-  bool deletable = 1;
-  bool cloneable = 2;
-  bool reorderable = 3;
-}
-
-// TextRunMessage is a plain text chunk.
-message TextRunMessage {
-  string text = 1;
-}
-
-// PlaceholderRunMessage is a self-closing inline code (variable,
-// conditional JSX expression, line break, icon, etc.).
-message PlaceholderRunMessage {
-  string id = 1;
-  string type = 2;      // Vocabulary key, e.g. "jsx:var", "jsx:node", "html:br".
-  string sub_type = 3;  // Fine-grained discriminator.
-  string data = 4;      // Original source slice, preserved verbatim.
-  string equiv = 5;     // Stable human-friendly identifier (variable name, tag name).
-  string disp = 6;      // Display label for chips.
-  RunConstraints constraints = 7;
-}
-
-// PcOpenRunMessage is the opening half of a paired inline code.
-message PcOpenRunMessage {
-  string id = 1;
-  string type = 2;
-  string sub_type = 3;
-  string data = 4;      // Raw opening source ("<span class=\"muted\">").
-  string equiv = 5;
-  string disp = 6;
-  RunConstraints constraints = 7;
-}
-
-// PcCloseRunMessage is the closing half of a paired inline code.
-// Shares id with its PcOpen inside the same runs scope.
-message PcCloseRunMessage {
-  string id = 1;
-  string type = 2;
-  string sub_type = 3;
-  string data = 4;      // Raw closing source ("</span>").
-  string equiv = 5;
-}
-
-// SubRunMessage is a reference to a subblock (sub-filter output).
-message SubRunMessage {
-  string id = 1;
-  string ref = 2;
-  string equiv = 3;
-}
-
-// PluralRunMessage is a structured plural construct. Keys of `forms`
-// are ICU plural forms: "zero", "one", "two", "few", "many", "other".
-message PluralRunMessage {
-  string pivot = 1;
-  map<string, RunList> forms = 2;
-}
-
-// SelectRunMessage is a structured select construct, symmetric to
-// PluralRunMessage but keyed by arbitrary case values.
-message SelectRunMessage {
-  string pivot = 1;
-  map<string, RunList> cases = 2;
-}
-
-// RunList is a repeated-field holder used by map values in
-// PluralRunMessage and SelectRunMessage (proto3 maps cannot have
-// repeated-message values directly).
-message RunList {
-  repeated RunMessage runs = 1;
-}
-
-// RunMessage is the discriminated-union inline-content primitive.
-// Exactly one of the oneof fields is present per Run.
-message RunMessage {
-  oneof kind {
-    TextRunMessage text = 1;
-    PlaceholderRunMessage ph = 2;
-    PcOpenRunMessage pc_open = 3;
-    PcCloseRunMessage pc_close = 4;
-    SubRunMessage sub = 5;
-    PluralRunMessage plural = 6;
-    SelectRunMessage select = 7;
-  }
-}
-
-// ────────────────────────────────────────────────────────────────────────────
-// Segments & Targets
-// ────────────────────────────────────────────────────────────────────────────
-
-// SegmentMessage represents a single segment within a Block.
-message SegmentMessage {
-  string id = 1;
-  repeated RunMessage runs = 2;
-  map<string, string> properties = 3;
-}
-
-// TargetEntry maps a locale to its target segments.
-message TargetEntry {
-  string locale = 1;
-  repeated SegmentMessage segments = 2;
-}
-
-// ────────────────────────────────────────────────────────────────────────────
-// Lightweight Block (for gRPC transfer — no skeleton, no display hints)
-// ────────────────────────────────────────────────────────────────────────────
-
-// ContentBlock is a lightweight representation of a translatable block
-// designed for efficient gRPC transfer. It carries only the fields that
-// Go-side tools need for content processing — source/target text with
-// inline markup, properties, and identity. The heavy fields (skeleton,
-// display hints, is_referent) stay on the Java side.
-//
-// Size comparison for a typical XLSX cell:
-//   BlockMessage:   ~500 bytes (skeleton dominates)
-//   ContentBlock:   ~50 bytes  (just id + text)
-message ContentBlock {
-  string id = 1;
-  string name = 2;
-  string type = 3;
-  string mime_type = 4;
-  bool translatable = 5;
-  repeated SegmentMessage source = 6;
-  repeated TargetEntry targets = 7;
-  map<string, string> properties = 8;
-  bool preserve_whitespace = 9;
-  map<string, AnnotationEntry> annotations = 10;
-  DisplayHintMessage display_hint = 11;
-}
-
-// ContentBlockBatch holds multiple ContentBlocks for batched gRPC transfer.
-message ContentBlockBatch {
-  repeated ContentBlock blocks = 1;
-}
-
-// ────────────────────────────────────────────────────────────────────────────
-// Skeleton
-// ────────────────────────────────────────────────────────────────────────────
-
-// SkeletonMessage preserves non-translatable structure for reconstruction.
-message SkeletonMessage {
-  int32 strategy = 1;                   // 0=FragmentBased, 1=Reparse
-  repeated SkeletonPartMessage parts = 2;
-  string source_uri = 3;
-}
-
-// SkeletonPartMessage is either a text fragment or a resource reference.
-message SkeletonPartMessage {
-  string text = 1;         // Literal text (set for text parts)
-  string resource_id = 2;  // Resource ID (set for reference parts)
-  string property = 3;     // Property to reference (e.g., "target", "source")
-  string locale = 4;       // Target locale for locale-specific references
-}
-
-// ────────────────────────────────────────────────────────────────────────────
-// Display Hints
-// ────────────────────────────────────────────────────────────────────────────
-
-// DisplayHintMessage provides rendering guidance for UI tools.
-message DisplayHintMessage {
-  int32 max_length = 1;     // Maximum character count (0 = unlimited)
-  string content_type = 2;  // Content type hint (e.g., "heading", "button")
-  string context = 3;       // Description of where this block appears
-  string preview = 4;       // Short preview of surrounding context
-}
-
-// ────────────────────────────────────────────────────────────────────────────
-// Content Units
-// ────────────────────────────────────────────────────────────────────────────
-
-// BlockMessage represents a translatable content unit.
-message BlockMessage {
-  string id = 1;
-  string name = 2;
-  string type = 3;
-  string mime_type = 4;
-  bool translatable = 5;
-  repeated SegmentMessage source = 6;
-  repeated TargetEntry targets = 7;
-  map<string, string> properties = 8;
-  map<string, AnnotationEntry> annotations = 9;
-  DisplayHintMessage display_hint = 10;
-  SkeletonMessage skeleton = 11;
-  bool preserve_whitespace = 12;
-  bool is_referent = 13;
-}
-
-// LayerMessage represents a structural layer.
-message LayerMessage {
-  string id = 1;
-  string name = 2;
-  string format = 3;
-  string locale = 4;
-  string encoding = 5;
-  string mime_type = 6;
-  string line_break = 7;
-  bool is_multilingual = 8;
-  string parent_id = 9;
-  map<string, string> properties = 10;
-  bool has_bom = 11;
-}
-
-// DataMessage represents non-translatable document structure.
-message DataMessage {
-  string id = 1;
-  string name = 2;
-  map<string, string> properties = 3;
-  SkeletonMessage skeleton = 4;
-  bool is_referent = 5;
-}
-
-// GroupStartMessage signals the beginning of a structural group.
-message GroupStartMessage {
-  string id = 1;
-  string name = 2;
-  string type = 3;
-  map<string, string> properties = 4;
-}
-
-// GroupEndMessage signals the end of a structural group.
-message GroupEndMessage {
-  string id = 1;
-}
-
-// MediaMessage holds binary or media content.
-message MediaMessage {
-  string id = 1;
-  string mime_type = 2;
-  bytes data = 3;
-  string uri = 4;
-  string alt_text = 5;
-  map<string, string> properties = 6;
-}
-
-// PartMessage is the fundamental unit flowing through the bridge.
-message PartMessage {
-  int32 part_type = 1;
-  // Only one of these is set, based on part_type.
-  BlockMessage block = 2;
-  LayerMessage layer = 3;
-  DataMessage data = 4;
-  GroupStartMessage group_start = 5;
-  GroupEndMessage group_end = 6;
-  MediaMessage media = 7;
-}
-
-// ────────────────────────────────────────────────────────────────────────────
 // Process RPC messages
 // ────────────────────────────────────────────────────────────────────────────
-
-// ContentRef allows passing content as a file path instead of inline bytes.
-message ContentRef {
-  oneof location {
-    bytes  inline = 1;  // Inline bytes
-    string path   = 2;  // Local filesystem path
-    string uri    = 3;  // Remote/local URI (file://, s3://, gs://)
-  }
-}
 
 // OutputRef specifies where to write output directly on disk.
 message OutputRef {
@@ -323,28 +75,33 @@ message OutputRef {
 // PartBatch holds multiple parts in a single gRPC message to amortize
 // per-message overhead (proto marshal, HTTP/2 framing, flush syscalls).
 message PartBatch {
-  repeated PartMessage parts = 1;
+  repeated neokapi.content.v1.PartMessage parts = 1;
+}
+
+// ContentBlockBatch holds multiple ContentBlocks for batched gRPC transfer.
+message ContentBlockBatch {
+  repeated neokapi.content.v1.ContentBlock blocks = 1;
 }
 
 // ProcessRequest is sent by the client (Go) to the server (Java).
 message ProcessRequest {
   oneof request {
-    ProcessHeader header = 1;           // First message: input/output config
-    PartMessage part = 2;               // Single processed part (legacy)
-    PartBatch part_batch = 3;           // Batched processed parts
-    ContentBlock content_block = 5;     // Single processed content block (lightweight)
-    ContentBlockBatch content_batch = 6; // Batched processed content blocks (preferred)
+    ProcessHeader header = 1;                          // First message: input/output config
+    neokapi.content.v1.PartMessage part = 2;           // Single processed part (legacy)
+    PartBatch part_batch = 3;                          // Batched processed parts
+    neokapi.content.v1.ContentBlock content_block = 5; // Single processed content block (lightweight)
+    ContentBlockBatch content_batch = 6;               // Batched processed content blocks (preferred)
   }
 }
 
 // ProcessResponse is sent by the server (Java) to the client (Go).
 message ProcessResponse {
   oneof response {
-    PartMessage part = 1;                // Single part (legacy)
-    ProcessReadDone read_done = 2;       // All parts have been read
-    ProcessComplete complete = 3;        // Output written, cycle complete
-    PartBatch part_batch = 4;            // Batched parts
-    ContentBlockBatch content_batch = 5; // Batched content blocks (lightweight, preferred)
+    neokapi.content.v1.PartMessage part = 1; // Single part (legacy)
+    ProcessReadDone read_done = 2;           // All parts have been read
+    ProcessComplete complete = 3;            // Output written, cycle complete
+    PartBatch part_batch = 4;                // Batched parts
+    ContentBlockBatch content_batch = 5;     // Batched content blocks (lightweight, preferred)
   }
 }
 
@@ -361,7 +118,7 @@ message InlineStep {
 // ProcessHeader configures the Process RPC.
 message ProcessHeader {
   string filter_class = 1;
-  ContentRef input = 2;              // Input document reference
+  neokapi.content.v1.ContentRef input = 2; // Input document reference
   string source_locale = 3;
   string target_locale = 4;
   string encoding = 5;
@@ -407,7 +164,7 @@ message ShutdownResponse {}
 message StepRequest {
   oneof request {
     StepHeader header = 1;
-    PartMessage part = 2;
+    neokapi.content.v1.PartMessage part = 2;
   }
 }
 
@@ -427,7 +184,7 @@ message StepHeader {
 // StepResponse is sent by the server (Java) to the client (Go).
 message StepResponse {
   oneof response {
-    PartMessage part = 1;
+    neokapi.content.v1.PartMessage part = 1;
     StepComplete complete = 2;
   }
 }
@@ -435,4 +192,23 @@ message StepResponse {
 // StepComplete signals that all parts have been processed by the step.
 message StepComplete {
   int32 parts_processed = 1;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Segment RPC messages
+// ────────────────────────────────────────────────────────────────────────────
+
+// SegmentRequest asks the daemon to segment one run of text.
+message SegmentRequest {
+  string engine = 1;               // segmenter name (capabilities.segmenters[].name)
+  string text = 2;                 // flattened, code-masked text to segment
+  string locale = 3;               // BCP-47 locale
+  map<string, string> params = 4;  // engine-specific params (e.g. model, threshold)
+}
+
+// SegmentResponse returns the interior boundaries — ascending rune (code-point)
+// offsets into SegmentRequest.text, excluding 0 and len(text).
+message SegmentResponse {
+  repeated int32 boundaries = 1;
+  string error = 2;
 }


### PR DESCRIPTION
neokapi moved the content-model messages verbatim into `core/proto/content/v1/content.proto` (same field numbers, same `java_package`), which the bridge proto now imports (neokapi/neokapi#1116). Both files are now vendored under `protoSourceRoot` (the import path resolves as-is; no pom or script change needed) — proto contents copied verbatim from the neokapi checkout.

Generated Java class FQNs are unchanged: `content.proto` keeps `java_package = "neokapi.bridge.proto"` + `java_multiple_files`, so `neokapi.bridge.proto.BlockMessage` etc. resolve exactly as before (spot-checked across Block/Part/Run/Overlay/Skeleton/ContentBlock); no Java source touched.

`make build V=1.47.0` BUILD SUCCESS; `make test` (1.48.0, Java 17): 131 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EWn2MKChfryUs7LBQz9az